### PR TITLE
Fix SSH host key verification in CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -166,8 +166,8 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
 
           # Add RPI Tailscale IP to known_hosts
-          ssh-keyscan -H ${{ env.RPI_TAILSCALE_IP }} 2>/dev/null | sort -u - ~/.ssh/known_hosts | uniq > ~/.ssh/known_hosts.tmp
-          mv ~/.ssh/known_hosts.tmp ~/.ssh/known_hosts
+          touch ~/.ssh/known_hosts
+          ssh-keyscan -H ${{ env.RPI_TAILSCALE_IP }} >> ~/.ssh/known_hosts 2>/dev/null
 
           # Verify SSH key format
           if ! ssh-keygen -l -f ~/.ssh/deploy_key > /dev/null 2>&1; then


### PR DESCRIPTION
- Fix 'Host key verification failed' error in GitHub Actions
- Create known_hosts file before adding host keys
- Simplify ssh-keyscan command (remove complex sort/uniq pipeline)

The previous implementation tried to merge with non-existent known_hosts file on fresh GitHub Actions runners, causing deployment failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Zoptymalizowano proces wdrażania poprzez uproszczenie konfiguracji SSH w przepływie ciągłego wdrażania.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->