### PR TITLE
Fix CD health check timeout for RPI4 slow startup

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -238,11 +238,14 @@ jobs:
       - name: Health check
         run: |
           echo "Waiting for application to start..."
+          echo "Spring Boot on RPI4 needs ~160s to start (PostgreSQL, MQTT, migrations)"
 
-          # Retry health check up to 12 times (60 seconds total)
-          # Spring Boot needs time to: connect to PostgreSQL, MQTT, run migrations, etc.
+          # Wait initial startup time, then retry a few times
           ssh -i ~/.ssh/deploy_key ${{ secrets.RPI_USER }}@${{ env.RPI_TAILSCALE_IP }} "
-            MAX_RETRIES=12
+            echo \"⏳ Waiting 180 seconds for Spring Boot startup...\"
+            sleep 180
+
+            MAX_RETRIES=5
             RETRY_DELAY=5
 
             for i in \$(seq 1 \$MAX_RETRIES); do
@@ -260,9 +263,9 @@ jobs:
               fi
             done
 
-            echo \"❌ Health check failed after \$MAX_RETRIES attempts\"
+            echo \"❌ Health check failed after 180s + \$MAX_RETRIES retries\"
             echo \"Checking application logs:\"
-            sudo journalctl -u ${{ env.APP_NAME }}.service -n 30 --no-pager
+            sudo journalctl -u ${{ env.APP_NAME }}.service -n 50 --no-pager
             exit 1
           "
 


### PR DESCRIPTION
## Problem
CD pipeline health check was failing because it only waited 60 seconds (12 × 5s retries), but Spring Boot on RPI4 needs **~160 seconds** to start.

## Root Cause
Measured startup time on RPI4:
```
Started ScadaSystemApplication in 160.397 seconds (process running for 168.92)
```

Spring Boot initialization includes:
- PostgreSQL connection
- Flyway migrations
- MQTT broker connection
- JPA entity manager setup
- WebSocket configuration

## Solution
Changed health check strategy from **many fast retries** to **wait + few retries**:

**Before:**
- 12 retries × 5 seconds = 60s total
- 11 failed attempts wasting CI time

**After:**
- Sleep 180 seconds (3 minutes - safe margin for 160s startup)
- Then 5 retries × 5 seconds = 25s buffer
- Total: 205 seconds maximum

## Benefits
- No wasted CI time on predictable failures
- Realistic timeout based on measured performance
- Still has retry buffer for timing variations

## Testing
Application confirmed working on RPI:
```bash
curl http://localhost:8080/health
{"status":"UP","service":"Energy Monitor Backend"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Ulepszono proces wdrażania aplikacji przez rozszerzenie czasu oczekiwania na sprawdzenie kondycji systemu.
  * Dostosowano logikę ponownych prób wdrażania w celu zwiększenia niezawodności.
  * Zwiększono liczbę rejestrowanych informacji diagnostycznych w przypadku problemów podczas uruchamiania.
  * Zaktualizowano komunikaty informacyjne związane z procesem inicjalizacji systemu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->