### PR TITLE
Fix: kalibracja współczynnika prądowego i progu szumów

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
   "enabledPlugins": {
-    "claude-mem@thedotmack": true
+    "claude-mem@thedotmack": false
   }
 }

--- a/esp32-firmware/src/main.cpp
+++ b/esp32-firmware/src/main.cpp
@@ -13,8 +13,8 @@
 #define PIN_I 35
 
 const float vCoeff = 0.550;
-const float iCoeff = 0.0096;
-const float NOISE_GATE_RMS = 0.05;  // Zwiększone z 0.01A - agresywniejsze filtrowanie przy małym obciążeniu
+const float iCoeff = 0.0283;
+const float NOISE_GATE_RMS = 0.15;  // Dostosowane do iCoeff=0.0283 (szum ADC ~0.10A wymaga wyższego progu)
 const float ADC_DEAD_ZONE = 4.0;
 const float THD_I_THRESHOLD = NOISE_GATE_RMS * 1.414 * 0.15;  // ~0.0106A - synchronized with NOISE_GATE (15% margin)
 


### PR DESCRIPTION
## Opis zmian
Dostosowanie współczynnika prądowego (`iCoeff`: 0.0096 → 0.0283) do rzeczywistej charakterystyki czujnika oraz podniesienie progu szumów (`NOISE_GATE_RMS`: 0.05 → 0.15) z uwagi na szum ADC ~0.10A przy nowym współczynniku.

## Powiązane issue
Closes #76

## Typ zmiany
- [x] Naprawa błędu (bug fix)
- [ ] Nowa funkcjonalność (feature)
- [ ] Refaktoryzacja (bez zmiany funkcjonalności)
- [x] Zmiana konfiguracji / infrastruktury
- [ ] Dokumentacja

## Zmiany w plikach
- `esp32-firmware/src/main.cpp` — zmiana `iCoeff` i `NOISE_GATE_RMS`
- `.claude/settings.json` — wyłączenie nieużywanego pluginu

## Jak przetestować
1. Flash firmware na ESP32
2. Zweryfikować odczyty prądu z kalibratorem lub znanym obciążeniem
3. Sprawdzić czy próg szumów poprawnie filtruje szum ADC przy braku obciążenia

## Checklist
- [x] Kod kompiluje się bez błędów
- [ ] Testy przechodzą (`npm test` / `mvn test`)
- [ ] Zmiany w firmware są spójne z symulatorem
- [ ] Sprawdzono na urządzeniu ESP32 (jeśli dotyczy firmware)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notatki wydania

* **Poprawki**
  * Ulepszono kalibrację czujnika prądu w oprogramowaniu układu ESP32.
  * Zwiększono próg szumów w celu poprawy filtracji sygnału.
  * Zoptymalizowano parametry detekcji harmonicznych zgodnie z nowymi ustawieniami szumów.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->