### PR TITLE
feat: externalize monitoring thresholds to @ConfigurationProperties (#40)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,136 @@
+# Copilot Instructions
+
+## Project Overview
+
+Web-based SCADA system for monitoring electrical power quality (bachelor's thesis project). Collects data from ESP32 measurement nodes (SCT013 current sensor + TV16 voltage transformer) via MQTT, stores it in PostgreSQL, and streams it to a React dashboard via WebSocket.
+
+**Modules:**
+- `scada-system/` — Spring Boot 3.5.6 backend (Java 17)
+- `webapp/` — React 19 + TypeScript frontend (Vite)
+- `esp32-firmware/` / `esp32-simulator/` — ESP32 firmware (PlatformIO)
+- `docker-compose.yml` — Local dev infrastructure (PostgreSQL + Mosquitto MQTT)
+
+## Build, Test & Run Commands
+
+### Backend (`cd scada-system`)
+```bash
+./mvnw spring-boot:run          # Run dev server (requires Docker infra running)
+./mvnw test                     # Run all tests (H2 in-memory, no infra needed)
+./mvnw clean package            # Build JAR
+
+# Run a single test class
+./mvnw test -Dtest=MeasurementServiceTest
+
+# Run a single test method
+./mvnw test -Dtest=MeasurementServiceTest#shouldSaveMeasurement
+```
+
+### Frontend (`cd webapp`)
+```bash
+npm run dev             # Dev server with hot reload
+npm run build           # Production build
+npm run lint            # ESLint
+npm run type-check      # TypeScript check
+npm run test            # Vitest
+npm run test:watch      # Watch mode
+npm run test:coverage   # Coverage report
+```
+
+### Infrastructure
+```bash
+docker-compose up -d    # Start PostgreSQL (port 5432) + Mosquitto (ports 1883, 9001)
+docker-compose down -v  # Stop and remove volumes
+```
+
+## Architecture
+
+### Data Flow
+```
+ESP32 (WiFi) → Mosquitto MQTT (tcp://localhost:1883)
+                     ↓
+        Spring Integration (MqttConfig)
+                     ↓
+        MqttMessageHandler → MeasurementService
+                     ↓
+               PostgreSQL
+                     ↓
+        WebSocketService → /topic/dashboard
+                     ↓
+           React Dashboard (native WebSocket)
+```
+
+### Backend Package Structure (`com.dkowalczyk.scadasystem`)
+| Package | Responsibility |
+|---------|---------------|
+| `config/` | MQTT, WebSocket, CORS, JPA, Async configuration |
+| `controller/` | REST endpoints (`/api/measurements`, `/api/stats`, `/api/dashboard`, `/api/health`) |
+| `model/entity/` | JPA entities: `Measurement`, `DailyStats` |
+| `model/dto/` | Request/response DTOs (separate from entities) |
+| `model/event/` | Spring application events (`MeasurementSavedEvent`) |
+| `repository/` | Spring Data JPA repositories |
+| `service/` | Business logic, MQTT handler, WebSocket broadcaster, stats aggregation |
+| `exception/` | `GlobalExceptionHandler` + custom exceptions |
+| `util/` | `Constants` (PN-EN 50160 thresholds), `MathUtils`, `DateTimeUtils` |
+
+### Key Configuration
+- **MQTT topics:** `scada/measurements/#` (QoS 1)
+- **WebSocket endpoint:** `/ws` → STOMP destination `/topic/dashboard`
+- **Database:** `energy_monitor` DB, user `energyuser`, Flyway migrations auto-run on startup
+- **Jackson:** `SNAKE_CASE` property naming strategy, ISO 8601 dates (not timestamps)
+- **Active profile:** `dev` by default; `test` in CI/tests (disables MQTT, uses H2)
+
+## Key Conventions
+
+### No Emojis in Code
+Never use emojis (✅, ⚠️, 🔥, etc.) in any source file (`.java`, `.ts`, `.tsx`, `.cpp`). Use plain text: `[OK]`, `[WARN]`, `[ERROR]`.
+
+### Test Structure — Four Base Classes
+All tests extend one of four base classes:
+
+| Base class | Use for | Context loaded |
+|------------|---------|---------------|
+| `BaseServiceTest` | Service unit tests | None — plain Mockito (`@Mock`, `@InjectMocks`) |
+| `BaseControllerTest` | Controller tests | Web layer only (`@WebMvcTest`) with all services auto-mocked |
+| `BaseRepositoryTest` | Repository tests | JPA slice (`@DataJpaTest`) with H2 |
+| `BaseIntegrationTest` | End-to-end tests | Full Spring context with H2 |
+
+All test classes use `@ActiveProfiles("test")`. The `test` profile disables MQTT autoconfiguration and switches to H2.
+
+### Entity Conventions
+- Entities use Lombok `@Data`, `@Builder`, `@NoArgsConstructor`, `@AllArgsConstructor`
+- Arrays (harmonics, waveforms) stored with `@JdbcTypeCode(SqlTypes.ARRAY)`
+- Timestamps use `Instant` (not `LocalDateTime`)
+- `@CreationTimestamp` for audit fields; no `@UpdateTimestamp` needed
+
+### DTO Conventions
+- Request DTOs end in `Request` (e.g., `MeasurementRequest`, `HistoryRequest`)
+- Response DTOs end in `DTO` (e.g., `MeasurementDTO`, `StatsDTO`)
+- DTOs are plain records or Lombok `@Data` classes — no JPA annotations
+
+### Exception Handling
+- `GlobalExceptionHandler` (`@RestControllerAdvice`) handles all exceptions
+- Error responses always include: `error`, `message`, `timestamp`; optionally `errorId` (UUID for 500s)
+- Business exceptions extend domain-specific classes (`MeasurementNotFoundException`)
+- Throw `IllegalArgumentException` for bad input validation at the service layer
+
+### Database Migrations (Flyway)
+- Migrations live in `src/main/resources/db/migration/`
+- Naming: `V{n}__{Description}.sql` (double underscore)
+- **Never modify existing migrations** — always add a new version
+- Current schema: V1–V5, V7 (note: V6 was skipped)
+- `spring.jpa.hibernate.ddl-auto=validate` — Hibernate only validates, never modifies schema
+
+### Electrical Domain Constants
+All PN-EN 50160 / IEC thresholds are in `util/Constants.java` — never hardcode values like `230.0` (nominal voltage), `50.0` (nominal frequency), or `8.0` (THD limit). The system monitors harmonics H1–H25 (partial, hardware-limited by Nyquist at ~1500 Hz).
+
+### Frontend Conventions
+- HTTP client: Axios (not fetch)
+- Server state: TanStack Query (React Query)
+- Real-time: native WebSocket API — no STOMP/SockJS
+- Component library: shadcn/ui (Radix UI + TailwindCSS) — base components in `src/ui/`
+- Page components in `src/views/`, reusable components in `src/components/`, hooks in `src/hooks/`
+- UI language: Polish
+
+### IDE
+- Backend: IntelliJ IDEA Ultimate (not Eclipse)
+- Frontend: Visual Studio Code

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/ScadaSystemApplication.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/ScadaSystemApplication.java
@@ -2,10 +2,12 @@ package com.dkowalczyk.scadasystem;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@ConfigurationPropertiesScan
 public class ScadaSystemApplication {
 
     public static void main(String[] args) {

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/config/MonitoringProperties.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/config/MonitoringProperties.java
@@ -1,0 +1,121 @@
+package com.dkowalczyk.scadasystem.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Externalized configuration for electrical monitoring thresholds.
+ *
+ * <p>Defaults follow EU standards (PN-EN 50160 / IEC 61000). Override any value in
+ * {@code application.properties}, via environment variables, or with a Spring profile
+ * for non-EU deployments.
+ *
+ * <p>Quick grid standard switch examples:
+ * <pre>
+ * # JVM argument
+ * --monitoring.frequency.nominal=60.0 --monitoring.voltage.nominal=120.0
+ *
+ * # Environment variable
+ * MONITORING_FREQUENCY_NOMINAL=60.0
+ *
+ * # Spring profile (application-us.properties)
+ * monitoring.voltage.nominal=120.0
+ * monitoring.frequency.nominal=60.0
+ * </pre>
+ *
+ * @author Bachelor Thesis - SCADA System Project
+ * @since 1.0
+ */
+@Component
+@ConfigurationProperties(prefix = "monitoring")
+@Data
+public class MonitoringProperties {
+
+    private Voltage voltage = new Voltage();
+    private Frequency frequency = new Frequency();
+    private PowerQuality powerQuality = new PowerQuality();
+
+    /**
+     * Voltage monitoring thresholds (PN-EN 50160 Group 1 + IEC 61000-2-2).
+     */
+    @Data
+    public static class Voltage {
+
+        /** Nominal supply voltage in volts (EU: 230V, US: 120V). */
+        private double nominal = 230.0;
+
+        /** Acceptable voltage tolerance as a fraction (PN-EN 50160: ±10% = 0.10). */
+        private double tolerance = 0.10;
+
+        /** Voltage sag threshold as a fraction of nominal (PN-EN 50160: 90% = 0.90). */
+        private double sagThresholdRatio = 0.90;
+
+        /** Voltage swell threshold as a fraction of nominal (PN-EN 50160: 110% = 1.10). */
+        private double swellThresholdRatio = 1.10;
+
+        /** Voltage interruption threshold as a fraction of nominal (PN-EN 50160: 10% = 0.10). */
+        private double interruptionThresholdRatio = 0.10;
+
+        /** Absolute voltage below which a sag is detected (nominal * sagThresholdRatio). */
+        public double getSagThreshold() {
+            return nominal * sagThresholdRatio;
+        }
+
+        /** Absolute voltage above which a swell is detected (nominal * swellThresholdRatio). */
+        public double getSwellThreshold() {
+            return nominal * swellThresholdRatio;
+        }
+
+        /** Absolute voltage below which an interruption is detected (nominal * interruptionThresholdRatio). */
+        public double getInterruptionThreshold() {
+            return nominal * interruptionThresholdRatio;
+        }
+
+        /** Upper voltage deviation limit in percent (+tolerance*100). */
+        public double getDeviationUpperLimit() {
+            return tolerance * 100.0;
+        }
+
+        /** Lower voltage deviation limit in percent (-tolerance*100). */
+        public double getDeviationLowerLimit() {
+            return -tolerance * 100.0;
+        }
+    }
+
+    /**
+     * Frequency monitoring thresholds (PN-EN 50160 Group 2 / IEC 61000-4-30).
+     */
+    @Data
+    public static class Frequency {
+
+        /** Nominal grid frequency in Hz (EU: 50.0, US: 60.0). */
+        private double nominal = 50.0;
+
+        /** Acceptable frequency deviation in Hz (PN-EN 50160: ±0.5 Hz). */
+        private double deviationLimitHz = 0.5;
+
+        /** Minimum acceptable frequency (nominal - deviationLimitHz). */
+        public double getMin() {
+            return nominal - deviationLimitHz;
+        }
+
+        /** Maximum acceptable frequency (nominal + deviationLimitHz). */
+        public double getMax() {
+            return nominal + deviationLimitHz;
+        }
+    }
+
+    /**
+     * Power quality thresholds (PN-EN 50160 Group 4 + IEC 61000-3-2).
+     */
+    @Data
+    public static class PowerQuality {
+
+        /** THD voltage limit in percent (PN-EN 50160: 8%, IEEE 519: 5%). */
+        private double thdVoltageLimit = 8.0;
+
+        /** Minimum acceptable power factor for load diagnostics. */
+        private double minPowerFactor = 0.85;
+    }
+}

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
@@ -1,10 +1,10 @@
 package com.dkowalczyk.scadasystem.service;
 
+import com.dkowalczyk.scadasystem.config.MonitoringProperties;
 import com.dkowalczyk.scadasystem.model.dto.*;
 import com.dkowalczyk.scadasystem.model.entity.Measurement;
 import com.dkowalczyk.scadasystem.model.event.MeasurementSavedEvent;
 import com.dkowalczyk.scadasystem.repository.MeasurementRepository;
-import com.dkowalczyk.scadasystem.util.Constants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,6 +30,7 @@ public class MeasurementService {
     private final WaveformService waveformService;
     private final ApplicationEventPublisher eventPublisher;
     private final MeasurementValidator validator;
+    private final MonitoringProperties monitoringProperties;
 
     /**
      * Helper method to get voltage and current waveforms.
@@ -97,8 +98,8 @@ public class MeasurementService {
         // PN-EN 50160 Group 1: Voltage deviation
         // Formula: (U_measured - U_nominal) / U_nominal * 100%
         if (measurement.getVoltageRms() != null) {
-            double deviation = ((measurement.getVoltageRms() - Constants.NOMINAL_VOLTAGE)
-                    / Constants.NOMINAL_VOLTAGE) * 100.0;
+            double nominalVoltage = monitoringProperties.getVoltage().getNominal();
+            double deviation = ((measurement.getVoltageRms() - nominalVoltage) / nominalVoltage) * 100.0;
             measurement.setVoltageDeviationPercent(deviation);
             log.debug("Calculated voltage deviation: {}% (U_rms={}V)",
                     String.format("%.2f", deviation), measurement.getVoltageRms());
@@ -107,7 +108,7 @@ public class MeasurementService {
         // PN-EN 50160 Group 2: Frequency deviation
         // Formula: f_measured - f_nominal
         if (measurement.getFrequency() != null) {
-            double deviation = measurement.getFrequency() - Constants.NOMINAL_FREQUENCY;
+            double deviation = measurement.getFrequency() - monitoringProperties.getFrequency().getNominal();
             measurement.setFrequencyDeviationHz(deviation);
             log.debug("Calculated frequency deviation: {} Hz (f={}Hz)",
                     String.format("%.3f", deviation), measurement.getFrequency());
@@ -310,8 +311,8 @@ public class MeasurementService {
         if (voltageDeviationPercent == null) {
             return null;
         }
-        return voltageDeviationPercent >= Constants.VOLTAGE_DEVIATION_LOWER_LIMIT_PERCENT
-                && voltageDeviationPercent <= Constants.VOLTAGE_DEVIATION_UPPER_LIMIT_PERCENT;
+        return voltageDeviationPercent >= monitoringProperties.getVoltage().getDeviationLowerLimit()
+                && voltageDeviationPercent <= monitoringProperties.getVoltage().getDeviationUpperLimit();
     }
 
     /**
@@ -321,7 +322,7 @@ public class MeasurementService {
         if (frequencyDeviationHz == null) {
             return null;
         }
-        return Math.abs(frequencyDeviationHz) <= Constants.FREQUENCY_DEVIATION_UPPER_LIMIT_HZ;
+        return Math.abs(frequencyDeviationHz) <= monitoringProperties.getFrequency().getDeviationLimitHz();
     }
 
     /**
@@ -332,7 +333,7 @@ public class MeasurementService {
         if (thdVoltage == null) {
             return null;
         }
-        return thdVoltage < Constants.VOLTAGE_THD_LIMIT;
+        return thdVoltage < monitoringProperties.getPowerQuality().getThdVoltageLimit();
     }
 
     private PowerQualityIndicatorsDTO buildPowerQualityIndicatorsDTO(Measurement measurement) {

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementValidator.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementValidator.java
@@ -4,10 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
+import com.dkowalczyk.scadasystem.config.MonitoringProperties;
 import com.dkowalczyk.scadasystem.model.dto.MeasurementRequest;
 import com.dkowalczyk.scadasystem.model.dto.ValidationResult;
-import com.dkowalczyk.scadasystem.util.Constants;
 import com.dkowalczyk.scadasystem.util.MathUtils;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Validates measurement data against safety thresholds and PN-EN 50160 standards.
@@ -19,7 +20,10 @@ import com.dkowalczyk.scadasystem.util.MathUtils;
  * @since 1.0
  */
 @Service
+@RequiredArgsConstructor
 public class MeasurementValidator {
+
+    private final MonitoringProperties monitoringProperties;
     /**
      * Validates measurement request against safety and quality standards.
      *
@@ -45,8 +49,8 @@ public class MeasurementValidator {
 
         if (voltageRms > 360.0) {
             errors.add("Błąd krytyczny: Napięcie " + voltageRms + "V przekracza próg bezpieczeństwa (360V).");
-        } else if (voltageRms < Constants.NOMINAL_VOLTAGE * (1 - Constants.VOLTAGE_TOLERANCE) ||
-                voltageRms > Constants.NOMINAL_VOLTAGE * (1 + Constants.VOLTAGE_TOLERANCE)) {
+        } else if (voltageRms < monitoringProperties.getVoltage().getNominal() * (1 - monitoringProperties.getVoltage().getTolerance()) ||
+                voltageRms > monitoringProperties.getVoltage().getNominal() * (1 + monitoringProperties.getVoltage().getTolerance())) {
             warnings.add("Ostrzeżenie: Napięcie " + voltageRms + "V poza normą PN-EN 50160.");
         }
 
@@ -56,17 +60,18 @@ public class MeasurementValidator {
         
         if (frequency < 45.0 || frequency > 55.0) {
             errors.add("Błąd krytyczny: Częstotliwość " + frequency + "Hz poza bezpiecznym zakresem (45-55Hz).");
-        } else if (frequency < Constants.FREQUENCY_MIN || 
-                   frequency > Constants.FREQUENCY_MAX) {
+        } else if (frequency < monitoringProperties.getFrequency().getMin() || 
+                   frequency > monitoringProperties.getFrequency().getMax()) {
             warnings.add("Ostrzeżenie: Częstotliwość " + frequency + "Hz poza normą PN-EN 50160.");
         }
         
-        if (powerFactor < Constants.MIN_POWER_FACTOR) {
+        if (powerFactor < monitoringProperties.getPowerQuality().getMinPowerFactor()) {
             warnings.add("Ostrzeżenie: Współczynnik mocy " + powerFactor + " poniżej 0.85 może wskazywać na problemy z efektywnością energetyczną.");
         }
         
-        if (thdVoltage > Constants.VOLTAGE_THD_LIMIT) {
-            warnings.add("Ostrzeżenie: THD napięcia " + thdVoltage + "% przekracza próg bezpieczeństwa (" + Constants.VOLTAGE_THD_LIMIT + "%).");
+        double thdLimit = monitoringProperties.getPowerQuality().getThdVoltageLimit();
+        if (thdVoltage > thdLimit) {
+            warnings.add("Ostrzeżenie: THD napięcia " + thdVoltage + "% przekracza próg bezpieczeństwa (" + thdLimit + "%).");
         }
 
         // Sanity check for apparent power

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 
+import com.dkowalczyk.scadasystem.config.MonitoringProperties;
 import com.dkowalczyk.scadasystem.model.dto.StatsDTO;
 import com.dkowalczyk.scadasystem.model.entity.DailyStats;
 import com.dkowalczyk.scadasystem.model.entity.Measurement;
@@ -32,6 +33,7 @@ public class StatsService {
 
     private final DailyStatsRepository repository;
     private final MeasurementRepository measurementRepository;
+    private final MonitoringProperties monitoringProperties;
 
     /**
      * Get today's statistics (used in homeowner dashboard).
@@ -135,37 +137,37 @@ public class StatsService {
         // Events must have minimum duration to be counted as valid
         int voltageSagCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getVoltageRms() < Constants.VOLTAGE_SAG_THRESHOLD,
+                m -> m.getVoltageRms() < monitoringProperties.getVoltage().getSagThreshold(),
                 Constants.SAG_MIN_DURATION_MS / 1000.0
         );
 
         int voltageSwellCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getVoltageRms() > Constants.VOLTAGE_SWELL_THRESHOLD,
+                m -> m.getVoltageRms() > monitoringProperties.getVoltage().getSwellThreshold(),
                 Constants.SAG_MIN_DURATION_MS / 1000.0  // Same duration threshold as sag
         );
 
         int interruptionCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getVoltageRms() < Constants.VOLTAGE_INTERRUPTION_THRESHOLD,
+                m -> m.getVoltageRms() < monitoringProperties.getVoltage().getInterruptionThreshold(),
                 Constants.VOLTAGE_INTERRUPTION_MIN_DURATION_SECONDS
         );
 
         int thdViolationsCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getThdVoltage() > Constants.VOLTAGE_THD_LIMIT,
+                m -> m.getThdVoltage() > monitoringProperties.getPowerQuality().getThdVoltageLimit(),
                 0.01  // 10ms minimum duration for THD violations
         );
 
         int frequencyDevCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getFrequency() < Constants.FREQUENCY_MIN || m.getFrequency() > Constants.FREQUENCY_MAX,
+                m -> m.getFrequency() < monitoringProperties.getFrequency().getMin() || m.getFrequency() > monitoringProperties.getFrequency().getMax(),
                 0.01  // 10ms minimum duration
         );
 
         int powerFactorPenaltyCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getPowerFactor() < Constants.MIN_POWER_FACTOR,
+                m -> m.getPowerFactor() < monitoringProperties.getPowerQuality().getMinPowerFactor(),
                 0.01  // 10ms minimum duration
         );
 

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/Constants.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/Constants.java
@@ -1,161 +1,77 @@
 package com.dkowalczyk.scadasystem.util;
 
 /**
- * Centralized utility class defining electrical measurement constants
- * based on PN-EN 50160 and IEC standards.
- * <p>
- * Includes:
- * - PN-EN 50160 power quality indicators
- * - Voltage standards (PN-EN 50160, IEC 61000-2-2)
- * - Harmonic limits (IEC 61000-4-7, IEC 61000-3-2)
- * - Frequency standards (PN-EN 50160, IEC 61000-4-30)
- * - Power factor thresholds
- * <p>
- * Note: Some limits reference full harmonic spectrum (2-40) per IEC standards,
- * but our system measures only harmonics 2-8 due to hardware sampling constraints.
+ * Hardware and timing constants for the SCADA measurement system.
+ *
+ * <p>Contains only fixed, hardware-derived, or IEC-standard timing values that are
+ * not deployment-configurable. Operational thresholds (voltage, frequency, THD, etc.)
+ * are externalized in {@link com.dkowalczyk.scadasystem.config.MonitoringProperties}.
+ *
+ * <p>Standards referenced:
+ * - IEC 61000-4-7: Harmonic measurement requirements
+ * - IEC 61000-4-30: Power quality measurement methods
+ * - PN-EN 50160: Voltage characteristics (event duration definitions)
  */
 public final class Constants {
 
+    // === PN-EN 50160 Group 5: Event Duration Timings ===
     /**
-     * Nominal voltage for single-phase EU grid (PN-EN 50160).
-     * Used as reference for voltage deviation calculation.
-     */
-    public static final double NOMINAL_VOLTAGE = 230.0;
-
-    // === PN-EN 50160 Group 1: Supply Voltage Magnitude ===
-    /**
-     * Voltage tolerance (±10%) per PN-EN 50160.
-     * Acceptable range: 207-253 V for 95% of week.
-     */
-    public static final double VOLTAGE_TOLERANCE = 0.10;
-    /**
-     * Voltage deviation upper limit (+10%) per PN-EN 50160.
-     */
-    public static final double VOLTAGE_DEVIATION_UPPER_LIMIT_PERCENT = 10.0;
-    /**
-     * Voltage deviation lower limit (-10%) per PN-EN 50160.
-     */
-    public static final double VOLTAGE_DEVIATION_LOWER_LIMIT_PERCENT = -10.0;
-    /**
-     * Nominal frequency for EU grid (PN-EN 50160).
-     * Used as reference for frequency deviation calculation.
-     */
-    public static final double NOMINAL_FREQUENCY = 50.0;
-
-    // === PN-EN 50160 Group 2: Supply Frequency ===
-    /**
-     * Frequency deviation upper limit (+0.5 Hz, +1%) per PN-EN 50160.
-     * Acceptable range: 49.5-50.5 Hz for 99.5% of year.
-     */
-    public static final double FREQUENCY_DEVIATION_UPPER_LIMIT_HZ = 0.5;
-    /**
-     * Frequency deviation lower limit (-0.5 Hz, -1%) per PN-EN 50160.
-     */
-    public static final double FREQUENCY_DEVIATION_LOWER_LIMIT_HZ = -0.5;
-    /**
-     * Minimum frequency per PN-EN 50160 (50 Hz - 1%).
-     */
-    public static final double FREQUENCY_MIN = 49.5;
-    /**
-     * Maximum frequency per PN-EN 50160 (50 Hz + 1%).
-     */
-    public static final double FREQUENCY_MAX = 50.5;
-    /**
-     * Frequency tolerance for IEC 61000-4-30 Class A measurements.
-     * Note: Our system achieves approximately ±0.01-0.02 Hz (Class S level).
-     */
-    public static final double FREQUENCY_TOLERANCE_CLASS_A = 0.01;
-    /**
-     * THD voltage limit per PN-EN 50160 and IEC 61000-4-7.
-     * Applies to full harmonic spectrum (harmonics 2-40).
-     * <p>
-     * IMPORTANT: Our system measures only harmonics 2-8 due to Nyquist limitation
-     * at 800-1000 Hz sampling rate. Calculated THD represents a LOWER BOUND of
-     * actual distortion (real THD may be higher due to unmeasured harmonics 9-40).
-     */
-    public static final double VOLTAGE_THD_LIMIT = 8.0;
-
-    // === PN-EN 50160 Group 4: Voltage Waveform Distortions ===
-    /**
-     * THD current limit per IEC 61000-3-2 (emission limits for equipment).
-     * <p>
-     * Note: This is a diagnostic parameter, not a PN-EN 50160 indicator.
-     * PN-EN 50160 focuses on voltage quality, not current.
-     * Our system measures only harmonics 2-8 (partial THD).
-     */
-    public static final double CURRENT_THD_LIMIT = 5.0;
-    /**
-     * Voltage dip (sag) threshold: 90% of nominal voltage per PN-EN 50160.
-     * Dip defined as: voltage drops to 10-90% of nominal for 10ms to 1 min.
-     */
-    public static final double VOLTAGE_SAG_THRESHOLD = NOMINAL_VOLTAGE * 0.90;
-
-    // === PN-EN 50160 Group 5: Supply Interruptions (Event Detection) ===
-    /**
-     * Temporary overvoltage (swell) threshold: 110% of nominal per PN-EN 50160.
-     * Swell defined as: voltage rises above 110% of nominal.
-     */
-    public static final double VOLTAGE_SWELL_THRESHOLD = NOMINAL_VOLTAGE * 1.10;
-    /**
-     * Interruption threshold: 10% of nominal voltage per PN-EN 50160.
-     * Interruption defined as: voltage drops below 10% of nominal.
-     */
-    public static final double VOLTAGE_INTERRUPTION_THRESHOLD = NOMINAL_VOLTAGE * 0.10;
-    /**
-     * Minimum duration for voltage dip/swell classification (10 ms).
-     * Events shorter than this may not be reliably detected.
+     * Minimum duration for voltage sag/swell classification (10 ms).
+     * Events shorter than this may not be reliably detected at current sampling rate.
      */
     public static final long SAG_MIN_DURATION_MS = 10;
+
     /**
-     * Maximum duration for voltage dip classification (1 minute = 60000 ms).
-     * Beyond this duration, event is classified differently.
+     * Maximum duration for voltage sag classification (1 minute = 60000 ms).
+     * Beyond this duration, event is classified differently per PN-EN 50160.
      */
     public static final long SAG_MAX_DURATION_MS = 60000;
+
     /**
      * Minimum duration for voltage interruption classification (10 ms = 0.01 s).
      * Per IEC 61000-4-30.
      */
     public static final double VOLTAGE_INTERRUPTION_MIN_DURATION_SECONDS = 0.01;
+
     /**
      * Short interruption duration threshold: 3 minutes = 180 seconds.
      * Short interruption: voltage &lt; 10% for 10 ms to 3 min.
      * Long interruption: voltage &lt; 10% for &gt; 3 min.
      */
     public static final long SHORT_INTERRUPTION_MAX_DURATION_SECONDS = 180;
-    /**
-     * Minimum acceptable power factor for industrial/commercial installations.
-     * Not defined by PN-EN 50160 (focuses on voltage quality, not load characteristics).
-     * Typical contractual requirement with energy suppliers.
-     */
-    public static final double MIN_POWER_FACTOR = 0.85;
 
-    // === Power Factor (Not a PN-EN 50160 indicator) ===
+    // === Measurement System Hardware Specifications ===
     /**
-     * Number of harmonics measured by the system.
-     * Limited by Nyquist constraint at 800-1000 Hz sampling rate.
-     * Includes fundamental (H1) + harmonics 2-8.
+     * Number of harmonics measurable by the system (H1–H25).
+     * Limited by Nyquist constraint at the ESP32 sampling rate.
      */
     public static final int HARMONICS_COUNT = 25;
 
-    // === Measurement System Specifications ===
     /**
-     * Sampling rate of ESP32 ADC (Hz).
-     * Conservative value with WiFi enabled.
+     * Sampling rate of ESP32 ADC in Hz (conservative value with WiFi enabled).
      */
     public static final int SAMPLING_RATE_HZ = 3000;
+
     /**
-     * Nyquist frequency: maximum measurable frequency (Hz).
-     * Nyquist = sampling_rate / 2.
+     * Nyquist frequency: maximum measurable frequency in Hz (sampling_rate / 2).
      */
     public static final int NYQUIST_FREQUENCY_HZ = SAMPLING_RATE_HZ / 2;
+
     /**
      * Maximum measurable harmonic order at current sampling rate.
-     * 1500 Hz / 50 Hz = 30th harmonic.
+     * Computed as: Nyquist / nominal_frequency = 1500 / 50 = 30.
+     * Note: nominal frequency (50 Hz) is inlined here as a hardware design constant.
      */
-    public static final int MAX_HARMONIC_ORDER = NYQUIST_FREQUENCY_HZ / (int) NOMINAL_FREQUENCY;
+    public static final int MAX_HARMONIC_ORDER = NYQUIST_FREQUENCY_HZ / 50;
+
+    /**
+     * Frequency measurement tolerance for IEC 61000-4-30 Class A measurements in Hz.
+     * Our zero-crossing method achieves approximately ±0.01–0.02 Hz (Class S level).
+     */
+    public static final double FREQUENCY_TOLERANCE_CLASS_A = 0.01;
 
     private Constants() {
         throw new AssertionError("Utility class cannot be instantiated");
     }
-
 }
+

--- a/scada-system/src/main/resources/application.properties
+++ b/scada-system/src/main/resources/application.properties
@@ -40,3 +40,20 @@ spring.jackson.property-naming-strategy=SNAKE_CASE
 logging.level.com.dkowalczyk.scadasystem=DEBUG
 logging.level.org.springframework.web=INFO
 logging.level.org.springframework.integration.mqtt=DEBUG
+
+# Monitoring thresholds (PN-EN 50160 / IEC 61000 defaults — EU 230V / 50 Hz grid)
+# Override without recompiling via JVM arg, env var, or Spring profile:
+#   JVM:  --monitoring.frequency.nominal=60.0 --monitoring.voltage.nominal=120.0
+#   Env:  MONITORING_FREQUENCY_NOMINAL=60.0
+#   Profile: create application-us.properties and set spring.profiles.active=us
+monitoring.voltage.nominal=230.0
+monitoring.voltage.tolerance=0.10
+monitoring.voltage.sag-threshold-ratio=0.90
+monitoring.voltage.swell-threshold-ratio=1.10
+monitoring.voltage.interruption-threshold-ratio=0.10
+
+monitoring.frequency.nominal=50.0
+monitoring.frequency.deviation-limit-hz=0.5
+
+monitoring.power-quality.thd-voltage-limit=8.0
+monitoring.power-quality.min-power-factor=0.85

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
@@ -1,6 +1,7 @@
 package com.dkowalczyk.scadasystem.service;
 
 import com.dkowalczyk.scadasystem.BaseServiceTest;
+import com.dkowalczyk.scadasystem.config.MonitoringProperties;
 import com.dkowalczyk.scadasystem.model.dto.MeasurementDTO;
 import com.dkowalczyk.scadasystem.model.dto.MeasurementRequest;
 import com.dkowalczyk.scadasystem.model.dto.PowerQualityIndicatorsDTO;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -33,6 +35,9 @@ class MeasurementServiceTest extends BaseServiceTest {
     private org.springframework.context.ApplicationEventPublisher eventPublisher;
     @Mock
     private MeasurementValidator validator;
+
+    @Spy
+    private MonitoringProperties monitoringProperties = new MonitoringProperties();
 
     @InjectMocks
     private MeasurementService measurementService;

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementValidatorTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementValidatorTest.java
@@ -6,12 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.dkowalczyk.scadasystem.config.MonitoringProperties;
 import com.dkowalczyk.scadasystem.model.dto.MeasurementRequest;
 import com.dkowalczyk.scadasystem.model.dto.ValidationResult;
 
 @DisplayName("MeasurementValidator Test")
 public class MeasurementValidatorTest {
-    private final MeasurementValidator validator = new MeasurementValidator();
+    private final MeasurementValidator validator = new MeasurementValidator(new MonitoringProperties());
 
     @Test
     void shouldReturnErrorWhenVoltageIsTooHigh() {

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
@@ -1,5 +1,6 @@
 package com.dkowalczyk.scadasystem.service;
 
+import com.dkowalczyk.scadasystem.config.MonitoringProperties;
 import com.dkowalczyk.scadasystem.model.dto.StatsDTO;
 import com.dkowalczyk.scadasystem.model.entity.DailyStats;
 import com.dkowalczyk.scadasystem.model.entity.Measurement;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 
@@ -41,6 +43,9 @@ class StatsServiceTest {
 
     @Mock
     private MeasurementRepository measurementRepository;
+
+    @Spy
+    private MonitoringProperties monitoringProperties = new MonitoringProperties();
 
     @InjectMocks
     private StatsService statsService;


### PR DESCRIPTION
## Summary

Closes #40

Moves all PN-EN 50160 / IEC 61000 operational thresholds out of the static `Constants.java` into a Spring `@ConfigurationProperties` bean, making them overridable without recompiling.

## Changes

### New
- `config/MonitoringProperties.java` — `@ConfigurationProperties(prefix="monitoring")` with nested `Voltage`, `Frequency`, and `PowerQuality` classes. Computed helpers (`getSagThreshold()`, `getMin()`, etc.) live inside each nested class.

### Modified
- `ScadaSystemApplication` — added `@ConfigurationPropertiesScan`
- `application.properties` — documented `monitoring.*` properties with override examples
- `MeasurementService`, `MeasurementValidator`, `StatsService` — inject `MonitoringProperties`, replace all `Constants.*` threshold refs
- `Constants.java` — trimmed to hardware/timing constants only (9 remain, 14 removed)
- `MeasurementServiceTest`, `StatsServiceTest` — added `@Spy MonitoringProperties` for `@InjectMocks` injection
- `MeasurementValidatorTest` — updated constructor call to `new MeasurementValidator(new MonitoringProperties())`

## Overriding thresholds (no recompile needed)

```bash
# JVM argument
java -jar scada-system.jar --monitoring.frequency.nominal=60.0 --monitoring.voltage.nominal=120.0

# Environment variable
export MONITORING_FREQUENCY_NOMINAL=60.0

# Spring profile (application-us.properties)
spring.profiles.active=us
```

## Testing

All 218 tests pass. Defaults are identical to previous hardcoded values — behaviour is unchanged out of the box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Informacje o wydaniu

* **Nowe funkcjonalności**
  * Parametry monitorowania systemu (napięcie, częstotliwość, jakość zasilania) mogą być teraz konfigurowane dynamicznie w czasie działania zamiast być sztywno zdefiniowane w kodzie.

* **Dokumentacja**
  * Dodano dokumentację kontekstu projektu, konwencji kodowania i procedur budowania oraz testowania.

* **Refaktor**
  * Uaktualniono usługi backend do korzystania z konfigurowalnych parametrów czasu wykonywania zamiast wartości stałych.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->