### PR TITLE
[codex] Fix undefined power factor handling

### DIFF
--- a/esp32-firmware/src/main.cpp
+++ b/esp32-firmware/src/main.cpp
@@ -269,13 +269,14 @@ void processingTask(void * pvParameters) {
 
         // Power factor λ = P/S (NOT cos(φ)!)
         // cos(φ) is only valid for sinusoidal waveforms
-        float powerFactor = (sApparent > 0.05) ? abs(pActive) / sApparent : 1.0;
+        bool powerFactorDefined = sApparent > 0.05;
+        float powerFactor = powerFactorDefined ? abs(pActive) / sApparent : 0.0;
         if (powerFactor > 1.0) powerFactor = 1.0;
 
         // Noise gate - zero out power readings for very low currents
         if (iRMS < NOISE_GATE_RMS) {
             iRMS = 0; pActive = 0; sApparent = 0;
-            qReactive_H1 = 0; powerDistortion = 0; powerFactor = 1.0;
+            qReactive_H1 = 0; powerDistortion = 0; powerFactor = 0.0; powerFactorDefined = false;
             // NOTE: hI_base and harmonics are NOT zeroed here - they're needed for THD calculation
             // THD threshold check will determine if THD should be calculated
             for(int i=1; i<=MAX_CALC_HARMONIC; i++) harmonicsI_out[i] = 0;
@@ -297,6 +298,9 @@ void processingTask(void * pvParameters) {
         doc["power_reactive"] = round(abs(qReactive_H1) * 10) / 10.0;  // Q1 - reactive power of fundamental only
         doc["power_distortion"] = round(powerDistortion * 10) / 10.0;  // D - distortion power from harmonics
         doc["power_factor"] = round(powerFactor * 100) / 100.0;        // λ = P/S (NOT cos(φ)!)
+        if (!powerFactorDefined) {
+            doc["power_factor"] = nullptr;  // Undefined when S = 0
+        }
         doc["freq"] = roundedFreq;
         doc["freq_valid"] = isFreqValid; // Dodatkowa flaga dla backendu
 

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
@@ -121,8 +121,8 @@ public class MeasurementService {
         Double apparentPower = request.getPowerApparent();
         Double currentRms = request.getCurrentRms();
 
-        if ((apparentPower != null && apparentPower <= 0.05)
-                || (currentRms != null && currentRms <= 0.0)) {
+        if ((apparentPower != null && apparentPower <= Constants.MIN_APPARENT_POWER_FOR_POWER_FACTOR_VA)
+                || (currentRms != null && currentRms <= Constants.MIN_CURRENT_RMS_FOR_POWER_FACTOR_A)) {
             return null;
         }
 

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
@@ -117,6 +117,18 @@ public class MeasurementService {
         // Note: Event detection (Group 5: voltage dips, interruptions) implemented separately
     }
 
+    private Double normalizePowerFactor(MeasurementRequest request) {
+        Double apparentPower = request.getPowerApparent();
+        Double currentRms = request.getCurrentRms();
+
+        if ((apparentPower != null && apparentPower <= 0.05)
+                || (currentRms != null && currentRms <= 0.0)) {
+            return null;
+        }
+
+        return request.getPowerFactor();
+    }
+
     /**
      * Saves a new measurement to the database and triggers WebSocket broadcast.
      * <p>
@@ -155,6 +167,7 @@ public class MeasurementService {
                 .waveformV(request.getWaveformV())               // Raw waveform data from ESP32
                 .waveformI(request.getWaveformI())               // Raw waveform data from ESP32
                 .build();
+        measurement.setPowerFactor(normalizePowerFactor(request));
 
         ValidationResult validationResult = validator.validate(request);
         measurement.setIsValid(validationResult.isValid());

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -121,7 +122,10 @@ public class StatsService {
         double maxFrequency = MathUtils.max(frequency);
 
         // === Power Factor Stats ===
-        List<Double> powerFactor = measurements.stream().map(Measurement::getPowerFactor).toList();
+        List<Double> powerFactor = measurements.stream()
+                .map(Measurement::getPowerFactor)
+                .filter(Objects::nonNull)
+                .toList();
         double avgPowerFactor = MathUtils.average(powerFactor);
         double minPowerFactor = MathUtils.min(powerFactor);
 
@@ -165,7 +169,7 @@ public class StatsService {
 
         int powerFactorPenaltyCount = countEventsWithDuration(
                 sortedMeasurements,
-                m -> m.getPowerFactor() < Constants.MIN_POWER_FACTOR,
+                m -> m.getPowerFactor() != null && m.getPowerFactor() < Constants.MIN_POWER_FACTOR,
                 0.01  // 10ms minimum duration
         );
 

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/Constants.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/Constants.java
@@ -129,6 +129,17 @@ public final class Constants {
      */
     public static final double MIN_POWER_FACTOR = 0.85;
 
+    /**
+     * Minimum apparent power required to treat power factor as defined.
+     * Below this threshold, lambda = P/S is not meaningful.
+     */
+    public static final double MIN_APPARENT_POWER_FOR_POWER_FACTOR_VA = 0.05;
+
+    /**
+     * Minimum RMS current required to treat power factor as defined.
+     */
+    public static final double MIN_CURRENT_RMS_FOR_POWER_FACTOR_A = 0.0;
+
     // === Power Factor (Not a PN-EN 50160 indicator) ===
     /**
      * Number of harmonics measured by the system.

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
@@ -212,4 +212,46 @@ class MeasurementServiceTest extends BaseServiceTest {
         assertThat(measurementCaptor.getValue().getPowerFactor()).isNull();
         assertThat(result.getPowerFactor()).isNull();
     }
+
+    @Test
+    void saveMeasurement_clearsPowerFactorWhenCurrentRmsIsZero() {
+        MeasurementRequest request = new MeasurementRequest();
+        request.setVoltageRms(222.0);
+        request.setCurrentRms(0.0);
+        request.setPowerActive(0.0);
+        request.setPowerReactive(0.0);
+        request.setPowerDistortion(0.0);
+        request.setPowerApparent(1.0);
+        request.setPowerFactor(1.0);
+        request.setFrequency(50.0);
+        request.setThdVoltage(16.4);
+
+        Measurement savedMeasurement = Measurement.builder()
+            .id(1L)
+            .time(Instant.now())
+            .voltageRms(222.0)
+            .currentRms(0.0)
+            .powerActive(0.0)
+            .powerReactive(0.0)
+            .powerDistortion(0.0)
+            .powerApparent(1.0)
+            .powerFactor(null)
+            .frequency(50.0)
+            .thdVoltage(16.4)
+            .voltageDeviationPercent(-3.4782608695652173)
+            .frequencyDeviationHz(0.0)
+            .isValid(true)
+            .build();
+
+        when(validator.validate(any())).thenReturn(new ValidationResult(true, Collections.emptyList(), Collections.emptyList()));
+        when(repository.save(any(Measurement.class))).thenReturn(savedMeasurement);
+
+        MeasurementDTO result = measurementService.saveMeasurement(request);
+
+        ArgumentCaptor<Measurement> measurementCaptor = ArgumentCaptor.forClass(Measurement.class);
+        verify(repository).save(measurementCaptor.capture());
+
+        assertThat(measurementCaptor.getValue().getPowerFactor()).isNull();
+        assertThat(result.getPowerFactor()).isNull();
+    }
 }

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
@@ -170,4 +170,46 @@ class MeasurementServiceTest extends BaseServiceTest {
             .isEqualTo(Instant.ofEpochSecond(expectedTimestamp));
         assertThat(result).isNotNull();
     }
+
+    @Test
+    void saveMeasurement_clearsPowerFactorWhenApparentPowerIsZero() {
+        MeasurementRequest request = new MeasurementRequest();
+        request.setVoltageRms(222.0);
+        request.setCurrentRms(0.0);
+        request.setPowerActive(0.0);
+        request.setPowerReactive(0.0);
+        request.setPowerDistortion(0.0);
+        request.setPowerApparent(0.0);
+        request.setPowerFactor(1.0);
+        request.setFrequency(50.0);
+        request.setThdVoltage(16.4);
+
+        Measurement savedMeasurement = Measurement.builder()
+            .id(1L)
+            .time(Instant.now())
+            .voltageRms(222.0)
+            .currentRms(0.0)
+            .powerActive(0.0)
+            .powerReactive(0.0)
+            .powerDistortion(0.0)
+            .powerApparent(0.0)
+            .powerFactor(null)
+            .frequency(50.0)
+            .thdVoltage(16.4)
+            .voltageDeviationPercent(-3.4782608695652173)
+            .frequencyDeviationHz(0.0)
+            .isValid(true)
+            .build();
+
+        when(validator.validate(any())).thenReturn(new ValidationResult(true, Collections.emptyList(), Collections.emptyList()));
+        when(repository.save(any(Measurement.class))).thenReturn(savedMeasurement);
+
+        MeasurementDTO result = measurementService.saveMeasurement(request);
+
+        ArgumentCaptor<Measurement> measurementCaptor = ArgumentCaptor.forClass(Measurement.class);
+        verify(repository).save(measurementCaptor.capture());
+
+        assertThat(measurementCaptor.getValue().getPowerFactor()).isNull();
+        assertThat(result.getPowerFactor()).isNull();
+    }
 }

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
@@ -406,6 +406,26 @@ class StatsServiceTest {
     }
 
     @Test
+    @DisplayName("calculateDailyStats() should ignore undefined power factor values")
+    void calculateDailyStats_shouldIgnoreUndefinedPowerFactorValues() {
+        Measurement noLoadMeasurement = createMeasurement(testDate, 0, 222.0, 0.0, 50.0, 0.95, 16.4);
+        noLoadMeasurement.setPowerFactor(null);
+        List<Measurement> measurements = List.of(
+                noLoadMeasurement,
+                createMeasurement(testDate, 3, 230.0, 1500.0, 50.0, 0.95, 5.0),
+                createMeasurement(testDate, 6, 231.0, 1600.0, 50.0, 0.96, 5.0)
+        );
+        mockRepositoryCalls(measurements);
+
+        StatsDTO result = statsService.calculateDailyStats(testDate);
+
+        assertThat(result.getAvgPowerFactor()).isCloseTo(0.955, org.assertj.core.data.Offset.offset(0.001));
+        assertThat(result.getMinPowerFactor()).isCloseTo(0.95, org.assertj.core.data.Offset.offset(0.001));
+        assertThat(result.getPowerFactorPenaltyCount()).isZero();
+        verify(dailyStatsRepository).save(any(DailyStats.class));
+    }
+
+    @Test
     @DisplayName("calculateDailyStats() should save entity to repository")
     void calculateDailyStats_shouldSaveEntity_toRepository() {
         // Given: Normal measurements

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
@@ -426,6 +426,25 @@ class StatsServiceTest {
     }
 
     @Test
+    @DisplayName("calculateDailyStats() should handle all undefined power factor values")
+    void calculateDailyStats_shouldHandleAllUndefinedPowerFactorValues() {
+        Measurement firstNoLoadMeasurement = createMeasurement(testDate, 0, 222.0, 0.0, 50.0, 0.95, 16.4);
+        Measurement secondNoLoadMeasurement = createMeasurement(testDate, 3, 223.0, 0.0, 50.0, 0.95, 12.0);
+        firstNoLoadMeasurement.setPowerFactor(null);
+        secondNoLoadMeasurement.setPowerFactor(null);
+        List<Measurement> measurements = List.of(firstNoLoadMeasurement, secondNoLoadMeasurement);
+        mockRepositoryCalls(measurements);
+
+        StatsDTO result = statsService.calculateDailyStats(testDate);
+
+        assertThat(result.getAvgPowerFactor()).isZero();
+        assertThat(result.getMinPowerFactor()).isZero();
+        assertThat(result.getPowerFactorPenaltyCount()).isZero();
+        assertThat(result.getMeasurementCount()).isEqualTo(2);
+        verify(dailyStatsRepository).save(any(DailyStats.class));
+    }
+
+    @Test
     @DisplayName("calculateDailyStats() should save entity to repository")
     void calculateDailyStats_shouldSaveEntity_toRepository() {
         // Given: Normal measurements

--- a/webapp/src/components/ParameterCard.tsx
+++ b/webapp/src/components/ParameterCard.tsx
@@ -7,7 +7,7 @@ interface ParameterCardProps {
   title: string;
   value: string;
   unit: string;
-  status: "normal" | "warning" | "critical";
+  status: "normal" | "warning" | "critical" | "unknown";
   statusLabel?: string;
   min: string;
   max: string;
@@ -33,7 +33,7 @@ export const ParameterCard = ({ title, value, unit, status, statusLabel, min, ma
   const numMax = parseFloat(max);
   const range = numMax - numMin;
   const percentage =
-    range === 0
+    !Number.isFinite(numValue) || !Number.isFinite(numMin) || !Number.isFinite(numMax) || range === 0
       ? 0
       : Math.min(100, Math.max(0, ((numValue - numMin) / range) * 100));
 
@@ -61,6 +61,7 @@ export const ParameterCard = ({ title, value, unit, status, statusLabel, min, ma
             "bg-success": status === "normal",
             "bg-warning": status === "warning",
             "bg-destructive": status === "critical",
+            "bg-muted": status === "unknown",
           })}
           style={{ width: `${percentage}%` }}
         />

--- a/webapp/src/components/StatusIndicator.tsx
+++ b/webapp/src/components/StatusIndicator.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@/lib/utils";
 
 interface StatusIndicatorProps {
-  status: "normal" | "warning" | "critical";
+  status: "normal" | "warning" | "critical" | "unknown";
   label: string;
   className?: string;
 }
@@ -11,6 +11,7 @@ export const StatusIndicator = ({ status, label, className }: StatusIndicatorPro
     normal: "bg-success",
     warning: "bg-warning",
     critical: "bg-destructive",
+    unknown: "bg-muted",
   };
 
   return (

--- a/webapp/src/test/ui/ParameterCard.test.tsx
+++ b/webapp/src/test/ui/ParameterCard.test.tsx
@@ -57,6 +57,14 @@ describe('ParameterCard Component - Comprehensive Suite', () => {
       const progressBar = container.querySelector('.h-full.transition-all');
       expect(progressBar).toHaveStyle({ width: '0%' });
     });
+
+    it('uses 0% width for non-numeric values', () => {
+      const { container } = render(
+        React.createElement(ParameterCard, { ...defaultProps, value: "N/A", status: "unknown" })
+      );
+      const progressBar = container.querySelector('.h-full.transition-all');
+      expect(progressBar).toHaveStyle({ width: '0%' });
+    });
   });
 
   describe('Status & Trend Styling', () => {
@@ -69,6 +77,9 @@ describe('ParameterCard Component - Comprehensive Suite', () => {
 
       rerender(React.createElement(ParameterCard, { ...defaultProps, status: 'critical' }));
       expect(container.querySelector('.bg-destructive')).toBeInTheDocument();
+
+      rerender(React.createElement(ParameterCard, { ...defaultProps, status: 'unknown' }));
+      expect(container.querySelector('.bg-muted')).toBeInTheDocument();
     });
 
     it('applies correct text colors for trends', () => {

--- a/webapp/src/test/ui/StatusIndicator.test.tsx
+++ b/webapp/src/test/ui/StatusIndicator.test.tsx
@@ -22,6 +22,12 @@ describe('StatusIndicator Component', () => {
       expect(screen.getByText('Alert')).toBeInTheDocument();
     });
 
+    it('renders with unknown status', () => {
+      render(<StatusIndicator status="unknown" label="N/D" />);
+
+      expect(screen.getByText('N/D')).toBeInTheDocument();
+    });
+
     it('renders label text', () => {
       render(<StatusIndicator status="normal" label="Test Label" />);
 
@@ -63,6 +69,15 @@ describe('StatusIndicator Component', () => {
       );
 
       const indicator = container.querySelector('.bg-destructive');
+      expect(indicator).toBeInTheDocument();
+    });
+
+    it('applies bg-muted for unknown status', () => {
+      const { container } = render(
+        <StatusIndicator status="unknown" label="Test" />
+      );
+
+      const indicator = container.querySelector('.bg-muted');
       expect(indicator).toBeInTheDocument();
     });
   });
@@ -153,7 +168,7 @@ describe('StatusIndicator Component', () => {
   });
 
   describe('All Status Types', () => {
-    const statuses = ['normal', 'warning', 'critical'] as const;
+    const statuses = ['normal', 'warning', 'critical', 'unknown'] as const;
 
     it('renders all status types without errors', () => {
       statuses.forEach((status) => {

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -17,7 +17,7 @@ export interface MeasurementDTO {
   power_reactive?: number;
   power_apparent?: number;
   power_distortion?: number;
-  power_factor?: number;
+  power_factor?: number | null;
   frequency?: number;
   thd_voltage?: number;
   thd_current?: number;

--- a/webapp/src/views/Dashboard.tsx
+++ b/webapp/src/views/Dashboard.tsx
@@ -105,13 +105,23 @@ const Dashboard = () => {
     return "normal";
   };
 
-  const getStatusLabel = (status: "normal" | "warning" | "critical") => {
+  const getStatusLabel = (status: "normal" | "warning" | "critical" | "unknown") => {
+    if (status === "unknown") return "N/D";
     const labels = {
       normal: "Normalny",
       warning: "Ostrzeżenie",
       critical: "Krytyczny",
     };
     return labels[status];
+  };
+
+  const getPowerFactorStatus = (
+    powerFactor: number | null | undefined,
+  ): "normal" | "warning" | "unknown" => {
+    if (powerFactor === null || powerFactor === undefined) return "unknown";
+    return powerFactor >= POWER_QUALITY_LIMITS.MIN_POWER_FACTOR
+      ? "normal"
+      : "warning";
   };
 
   const getTrend = (
@@ -312,17 +322,9 @@ const Dashboard = () => {
                   "N/A"
                 }
                 unit="λ"
-                status={
-                  (dashboardData.latest_measurement.power_factor ?? 0) >=
-                  POWER_QUALITY_LIMITS.MIN_POWER_FACTOR
-                    ? "normal"
-                    : "warning"
-                }
+                status={getPowerFactorStatus(dashboardData.latest_measurement.power_factor)}
                 statusLabel={getStatusLabel(
-                  (dashboardData.latest_measurement.power_factor ?? 0) >=
-                    POWER_QUALITY_LIMITS.MIN_POWER_FACTOR
-                    ? "normal"
-                    : "warning",
+                  getPowerFactorStatus(dashboardData.latest_measurement.power_factor),
                 )}
                 min="0.85"
                 max="1.0"


### PR DESCRIPTION
## What changed

- Report power factor as `null` from ESP32 firmware when apparent power is zero.
- Normalize incoming measurements in the backend so `powerFactor` is stored as `null` whenever `S = 0` or current is zero, even if older firmware sends `1.0`.
- Update daily statistics to ignore undefined power factor values and avoid counting them as low power factor events.
- Update the dashboard to show `N/A` with an unknown status instead of treating undefined power factor as a warning.
- Add backend and frontend tests covering undefined power factor handling.

## Why

Power factor is defined as `lambda = P / S`. When no load is connected, `P = 0` and `S = 0`, so the value is mathematically undefined. Showing `1.0` made the dashboard look like it had measured a valid ideal power factor, which was incorrect.

## Validation

- `git diff --check` passed.
- Local backend tests were not run because `JAVA_HOME` is not configured in this environment.
- Local frontend tests were not run because `npm`/Node are not available in PATH.
- Per request, no further local tests were run; PR checks should validate the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Wprowadzono stan „nieznany” dla wskaźników i kart parametrów (oznaczenie „N/D”).
  * W panelu „Współczynnik mocy” wartość może być wyświetlana jako „N/D”, gdy nie da się jej wiarygodnie wyznaczyć.

* **Poprawki**
  * Uporządkowano obsługę współczynnika mocy: wartości niezdefiniowane są zapisywane jako puste i pomijane w statystykach.
  * Dodano walidację obliczeń procentu paska postępu (błędne/niefinite dane skutkują 0%).

* **Testy**
  * Rozszerzono testy jednostkowe i UI o przypadki wartości `null` oraz status „unknown”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->