### PR TITLE
[codex] Show distortion power on dashboard

### DIFF
--- a/webapp/src/views/Dashboard.tsx
+++ b/webapp/src/views/Dashboard.tsx
@@ -93,18 +93,6 @@ const Dashboard = () => {
     return "normal";
   };
 
-  const getFrequencyStatus = (
-    freq: number,
-  ): "normal" | "warning" | "critical" => {
-    if (
-      freq < POWER_QUALITY_LIMITS.FREQUENCY_MIN ||
-      freq > POWER_QUALITY_LIMITS.FREQUENCY_MAX
-    ) {
-      return "critical";
-    }
-    return "normal";
-  };
-
   const getStatusLabel = (status: "normal" | "warning" | "critical" | "unknown") => {
     if (status === "unknown") return "N/D";
     const labels = {
@@ -292,23 +280,19 @@ const Dashboard = () => {
                 )}
               />
               <ParameterCard
-                title="Częstotliwość"
-                value={(dashboardData.latest_measurement.frequency ?? 0).toFixed(2)}
-                unit="Hz"
-                status={getFrequencyStatus(
-                  dashboardData.latest_measurement.frequency ?? 0,
-                )}
-                statusLabel={getStatusLabel(
-                  getFrequencyStatus(
-                    dashboardData.latest_measurement.frequency ?? 0,
-                  ),
-                )}
-                min="49.50"
-                max="50.50"
+                title="Moc odkształcenia"
+                value={(
+                  dashboardData.latest_measurement.power_distortion ?? 0
+                ).toFixed(1)}
+                unit="var"
+                status="normal"
+                statusLabel="Diagnostyczny"
+                min="0"
+                max="1000"
                 trend={getTrend(
-                  dashboardData.latest_measurement.frequency ?? 0,
+                  dashboardData.latest_measurement.power_distortion ?? 0,
                   dashboardData.recent_history,
-                  "frequency",
+                  "power_distortion",
                 )}
               />
             </div>


### PR DESCRIPTION
## Summary
- Replace the top dashboard frequency card with distortion power (`power_distortion`).
- Show the Polish label `Moc odkształcenia`, `var` units, and trend data from the distortion power field.
- Remove the now-unused frequency status helper from the dashboard view.

## Why
The backend and data model already expose distortion power, but the dashboard on `master` still displayed `Częstotliwość`. Machines running from `master` therefore could not see the distortion power metric in that card.

## Validation
- `npm run type-check` in `webapp/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nowe funkcje**
  * W sekcji parametrów w czasie rzeczywistym dodano nową kartę „Moc odkształcenia”.
  * Karta pokazuje bieżącą wartość oraz trend dla tego parametru.

* **Zmiany w widoku**
  * W pierwszym wierszu kart zastąpiono „Częstotliwość” nowym parametrem diagnostycznym.
  * Zmieniono prezentację danych, aby lepiej eksponować odczyt z najnowszego pomiaru.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->