### PR TITLE
[codex] Fix reactive power unit display

### DIFF
--- a/webapp/src/views/Dashboard.tsx
+++ b/webapp/src/views/Dashboard.tsx
@@ -320,16 +320,14 @@ const Dashboard = () => {
               />
               <ParameterCard
                 title="Moc bierna"
-                value={(
-                  (dashboardData.latest_measurement.power_reactive ?? 0) / 1000
-                ).toFixed(2)}
-                unit="kVAR"
+                value={(dashboardData.latest_measurement.power_reactive ?? 0).toFixed(1)}
+                unit="VAR"
                 status="normal"
                 statusLabel="Normalny"
                 min="0"
-                max="2.0"
+                max="2000"
                 trend={getTrend(
-                  (dashboardData.latest_measurement.power_reactive ?? 0) / 1000,
+                  dashboardData.latest_measurement.power_reactive ?? 0,
                   dashboardData.recent_history,
                   "power_reactive",
                 )}


### PR DESCRIPTION
## Summary
- Display `Moc bierna` directly in `VAR` instead of converting to `kVAR`.
- Update the displayed range from `0-2.0` to `0-2000`.
- Use the raw `power_reactive` value for the trend calculation so the value and unit are consistent.

## Why
The dashboard label requested for reactive power should use `VAR`. Keeping the previous division by `1000` while only changing the label would show incorrect values, so the conversion was removed as part of the unit fix.

## Validation
- `npm run type-check` in `webapp/`