### PR TITLE
[codex] Implement ADC continuous sampling

### DIFF
--- a/esp32-firmware/src/main.cpp
+++ b/esp32-firmware/src/main.cpp
@@ -3,20 +3,29 @@
 #include <PubSubClient.h>
 #include <ArduinoJson.h>
 #include <arduinoFFT.h>
+#include <driver/adc.h>
+#include <hal/adc_ll.h>
 #include "config.h"
 
 // --- PARAMETRY POMIAROWE ---
-#define SAMPLES 512
-#define SAMPLING_FREQ 3000 
+#define SAMPLES 1024
+#define SAMPLING_FREQ 10000
+#define WAVEFORM_EXPORT_PERIODS 2
 #define MAX_CALC_HARMONIC 25
 #define PIN_U 33
 #define PIN_I 35
+#define ADC_CHANNEL_U ADC1_CHANNEL_5
+#define ADC_CHANNEL_I ADC1_CHANNEL_7
+#define ADC_PATTERN_LEN 2
+#define ADC_TOTAL_SAMPLE_FREQ (SAMPLING_FREQ * ADC_PATTERN_LEN)
+#define ADC_DMA_FRAME_BYTES 1024
 
 const float vCoeff = 0.550;
 const float iCoeff = 0.0283;
 const float NOISE_GATE_RMS = 0.15;  // Dostosowane do iCoeff=0.0283 (szum ADC ~0.10A wymaga wyższego progu)
 const float ADC_DEAD_ZONE = 4.0;
 const float THD_I_THRESHOLD = NOISE_GATE_RMS * 1.414 * 0.15;  // ~0.0106A - synchronized with NOISE_GATE (15% margin)
+const bool SMOOTH_WAVEFORM_CURRENT = true;
 
 // Zero-crossing detection parameters
 const float ZERO_CROSSING_THRESHOLD = 8.0;  // LSB units (optymalna histereza ~4.4V - kompromis między czułością a odpornością na szum)
@@ -26,37 +35,128 @@ const int MIN_ZERO_CROSSINGS = 2;           // Min 2 przejścia = 1 pełny okres
 volatile int rawBufferU[SAMPLES];
 volatile int rawBufferI[SAMPLES];
 volatile bool dataReady = false;
-volatile int sampleIdx = 0;
 
 double vReal[SAMPLES], vImag[SAMPLES];
 double iReal[SAMPLES], iImag[SAMPLES];
+double waveformV_out[SAMPLES];
+double waveformI_out[SAMPLES];
 ArduinoFFT<double> FFT = ArduinoFFT<double>();
 
 WiFiClient espClient;
 PubSubClient client(espClient);
-hw_timer_t * timer = NULL;
 unsigned long lastPublishTime = 0;
 double lastValidFreqZC = 50.0;  // Ostatnia prawidłowa częstotliwość z zero-crossing (fallback)
-
-void IRAM_ATTR onTimer() {
-  if (!dataReady) {
-    // Szybki, pojedynczy odczyt dla zachowania precyzji bazy czasu
-    rawBufferU[sampleIdx] = analogRead(PIN_U);
-    rawBufferI[sampleIdx] = analogRead(PIN_I);
-    
-    sampleIdx++;
-    if (sampleIdx >= SAMPLES) {
-      sampleIdx = 0;
-      dataReady = true;
-    }
-  }
-}
 
 void setup_wifi() {
     Serial.printf("\nConnecting to %s...", WIFI_SSID);
     WiFi.begin(WIFI_SSID, WIFI_PASS);
     while (WiFi.status() != WL_CONNECTED) { delay(500); Serial.print("."); }
     Serial.println("\nWiFi Connected.");
+}
+
+void setup_adc_dma() {
+    adc1_config_width(ADC_WIDTH_BIT_12);
+    adc1_config_channel_atten(ADC_CHANNEL_U, ADC_ATTEN_DB_12);
+    adc1_config_channel_atten(ADC_CHANNEL_I, ADC_ATTEN_DB_12);
+
+    adc_digi_init_config_t initConfig = {
+        .max_store_buf_size = ADC_DMA_FRAME_BYTES * 4,
+        .conv_num_each_intr = ADC_DMA_FRAME_BYTES,
+        .adc1_chan_mask = BIT(ADC_CHANNEL_U) | BIT(ADC_CHANNEL_I),
+        .adc2_chan_mask = 0,
+    };
+
+    esp_err_t err = adc_digi_initialize(&initConfig);
+    if (err != ESP_OK) {
+        Serial.printf("[ADC-DMA] initialize failed: %d\n", err);
+        while (true) delay(1000);
+    }
+
+    static adc_digi_pattern_config_t adcPattern[ADC_PATTERN_LEN] = {};
+    adcPattern[0].atten = ADC_ATTEN_DB_12;
+    adcPattern[0].channel = ADC_CHANNEL_U;
+    adcPattern[0].unit = ADC_NUM_1;
+    adcPattern[0].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
+    adcPattern[1].atten = ADC_ATTEN_DB_12;
+    adcPattern[1].channel = ADC_CHANNEL_I;
+    adcPattern[1].unit = ADC_NUM_1;
+    adcPattern[1].bit_width = SOC_ADC_DIGI_MAX_BITWIDTH;
+
+    adc_digi_configuration_t digConfig = {
+        .conv_limit_en = true,
+        .conv_limit_num = 255,
+        .pattern_num = ADC_PATTERN_LEN,
+        .adc_pattern = adcPattern,
+        .sample_freq_hz = ADC_TOTAL_SAMPLE_FREQ,
+        .conv_mode = ADC_CONV_SINGLE_UNIT_1,
+        .format = ADC_DIGI_OUTPUT_FORMAT_TYPE1,
+    };
+
+    err = adc_digi_controller_configure(&digConfig);
+    if (err != ESP_OK) {
+        Serial.printf("[ADC-DMA] controller config failed: %d\n", err);
+        while (true) delay(1000);
+    }
+
+    err = adc_digi_start();
+    if (err != ESP_OK) {
+        Serial.printf("[ADC-DMA] start failed: %d\n", err);
+        while (true) delay(1000);
+    }
+
+    Serial.printf("[ADC-DMA] started: %d Hz per channel, %d Hz total scan rate\n",
+                  SAMPLING_FREQ, ADC_TOTAL_SAMPLE_FREQ);
+}
+
+void adcSamplingTask(void * pvParameters) {
+    static uint8_t dmaBuffer[ADC_DMA_FRAME_BYTES];
+    static int frameU[SAMPLES];
+    static int frameI[SAMPLES];
+    int idxU = 0;
+    int idxI = 0;
+
+    for (;;) {
+        uint32_t bytesRead = 0;
+        esp_err_t err = adc_digi_read_bytes(dmaBuffer, sizeof(dmaBuffer), &bytesRead, 1000);
+        if (err == ESP_ERR_TIMEOUT) {
+            continue;
+        }
+        if (err == ESP_ERR_INVALID_STATE) {
+            Serial.println("[ADC-DMA] overflow: sampling faster than processing");
+            vTaskDelay(pdMS_TO_TICKS(10));
+            continue;
+        }
+        if (err != ESP_OK) {
+            Serial.printf("[ADC-DMA] read failed: %d\n", err);
+            vTaskDelay(pdMS_TO_TICKS(100));
+            continue;
+        }
+
+        int sampleCount = bytesRead / sizeof(adc_digi_output_data_t);
+        adc_digi_output_data_t *samples = (adc_digi_output_data_t *)dmaBuffer;
+        for (int i = 0; i < sampleCount; i++) {
+            uint8_t channel = samples[i].type1.channel;
+            uint16_t value = samples[i].type1.data;
+
+            if (channel == ADC_CHANNEL_U && idxU < SAMPLES) {
+                frameU[idxU++] = value;
+            } else if (channel == ADC_CHANNEL_I && idxI < SAMPLES) {
+                frameI[idxI++] = value;
+            }
+
+            if (idxU >= SAMPLES && idxI >= SAMPLES) {
+                if (!dataReady) {
+                    for (int j = 0; j < SAMPLES; j++) {
+                        rawBufferU[j] = frameU[j];
+                        rawBufferI[j] = frameI[j];
+                    }
+                    dataReady = true;
+                }
+                idxU = 0;
+                idxI = 0;
+            }
+        }
+    }
 }
 
 /**
@@ -72,14 +172,17 @@ float calculateFrequencyFromZeroCrossing(volatile int* rawBuffer, int numSamples
     int zeroCrossingSamples[MAX_ZERO_CROSSINGS];  // Indeksy próbek, nie czasy
     int crossingCount = 0;
 
-    // Wykryj rising edge zero-crossings (bez interpolacji, stała histereza)
-    for (int i = 1; i < numSamples && crossingCount < MAX_ZERO_CROSSINGS; i++) {
-        float v_prev = (rawBuffer[i-1] - dcOffset);  // Raw ADC units
-        float v_curr = (rawBuffer[i] - dcOffset);
+    // Stateful hysteresis: at higher sample rates the signal may spend several
+    // samples inside the deadband, so consecutive-sample crossing is unreliable.
+    bool armedForRising = false;
+    for (int i = 0; i < numSamples && crossingCount < MAX_ZERO_CROSSINGS; i++) {
+        float v_curr = (rawBuffer[i] - dcOffset);  // Raw ADC units
 
-        // Rising edge: negative → positive (z histerezą)
-        if (v_prev < -ZERO_CROSSING_THRESHOLD && v_curr > ZERO_CROSSING_THRESHOLD) {
+        if (v_curr < -ZERO_CROSSING_THRESHOLD) {
+            armedForRising = true;
+        } else if (armedForRising && v_curr > ZERO_CROSSING_THRESHOLD) {
             zeroCrossingSamples[crossingCount++] = i;  // Zapisz tylko indeks próbki
+            armedForRising = false;
         }
     }
 
@@ -93,8 +196,7 @@ float calculateFrequencyFromZeroCrossing(volatile int* rawBuffer, int numSamples
         return 0.0;
     }
 
-    // Oblicz średni okres z kolejnych przejść z filtracją outlierów
-    // Okres = różnica indeksów × 333 μs na próbkę
+    // Oblicz średni okres z kolejnych przejść z filtracją outlierów.
 
     // Krok 1: Oblicz wstępną średnią do określenia zakresu outlierów
     int totalSamples = 0;
@@ -124,7 +226,7 @@ float calculateFrequencyFromZeroCrossing(volatile int* rawBuffer, int numSamples
     }
 
     float avgSamples = (float)validSamples / (float)validCount;
-    float avgPeriodUs = avgSamples * 333.0;  // 333 μs = okres próbkowania
+    float avgPeriodUs = avgSamples * (1000000.0 / SAMPLING_FREQ);
     float frequency = 1000000.0 / avgPeriodUs;  // Konwersja μs na Hz
 
     // Serial.printf("[ZC-DEBUG] avgSamples=%.1f, frequency=%.2f Hz\n", avgSamples, frequency);
@@ -157,26 +259,35 @@ void processingTask(void * pvParameters) {
         // 2. Przygotowanie danych i RMS
         double sumU2 = 0, sumI2 = 0, sumP = 0;
 
-        // Store raw waveform samples for frontend (BEFORE FFT modifies vReal/iReal arrays)
-        double waveformV_out[SAMPLES];
-        double waveformI_out[SAMPLES];
-
         for (int i = 0; i < SAMPLES; i++) {
             float uScaled = (rawBufferU[i] - offsetU) * vCoeff;
             float iRaw = (float)rawBufferI[i] - offsetI;
-            if (abs(iRaw) < ADC_DEAD_ZONE) iRaw = 0;
-            float iScaled = iRaw * iCoeff;
+            float iDisplayScaled = iRaw * iCoeff;
+            float iCalcRaw = iRaw;
+            if (abs(iCalcRaw) < ADC_DEAD_ZONE) iCalcRaw = 0;
+            float iScaled = iCalcRaw * iCoeff;
 
             vReal[i] = (double)uScaled; vImag[i] = 0;
             iReal[i] = (double)iScaled; iImag[i] = 0;
 
             // Save raw samples for waveform display
             waveformV_out[i] = uScaled;
-            waveformI_out[i] = iScaled;
+            waveformI_out[i] = iDisplayScaled;
 
             sumU2 += uScaled * uScaled;
             sumI2 += iScaled * iScaled;
             sumP += uScaled * iScaled;
+        }
+
+        if (SMOOTH_WAVEFORM_CURRENT && SAMPLES > 2) {
+            double prev = waveformI_out[0];
+            double curr = waveformI_out[1];
+            for (int i = 1; i < SAMPLES - 1; i++) {
+                double next = waveformI_out[i + 1];
+                waveformI_out[i] = (prev + 2.0 * curr + next) / 4.0;
+                prev = curr;
+                curr = next;
+            }
         }
 
         float vRMS = sqrt(sumU2 / SAMPLES);
@@ -280,6 +391,7 @@ void processingTask(void * pvParameters) {
             // NOTE: hI_base and harmonics are NOT zeroed here - they're needed for THD calculation
             // THD threshold check will determine if THD should be calculated
             for(int i=1; i<=MAX_CALC_HARMONIC; i++) harmonicsI_out[i] = 0;
+            for(int i=0; i<SAMPLES; i++) waveformI_out[i] = 0;
         }
 
         float roundedFreq = round(freq * 10) / 10.0;
@@ -297,7 +409,7 @@ void processingTask(void * pvParameters) {
         doc["power_apparent"] = round(sApparent * 10) / 10.0;
         doc["power_reactive"] = round(abs(qReactive_H1) * 10) / 10.0;  // Q1 - reactive power of fundamental only
         doc["power_distortion"] = round(powerDistortion * 10) / 10.0;  // D - distortion power from harmonics
-        doc["power_factor"] = round(powerFactor * 100) / 100.0;        // λ = P/S (NOT cos(φ)!)
+        doc["power_factor"] = powerFactor;                            // λ = P/S (NOT cos(φ)!)
         if (!powerFactorDefined) {
             doc["power_factor"] = nullptr;  // Undefined when S = 0
         }
@@ -314,20 +426,21 @@ void processingTask(void * pvParameters) {
             hI_arr.add(round(harmonicsI_out[h] * 1000) / 1000.0);
         }
 
-        // Add raw waveform data (3 cycles ~181 samples for frontend zero-crossing trimming)
+        // Add raw waveform data at the full sampling rate. Export only two periods
+        // to keep MQTT payload bounded while improving chart detail.
         JsonArray waveV_arr = doc["waveform_v"].to<JsonArray>();
         JsonArray waveI_arr = doc["waveform_i"].to<JsonArray>();
-        int samplesPerCycle = round(SAMPLING_FREQ / freq);  // Use detected frequency, not hardcoded 50Hz
-        // Send 1 full cycle + 1 extra sample to complete the period visually
-        int samplesToSend = 3 * samplesPerCycle + 1;
-        if (samplesToSend > SAMPLES) samplesToSend = SAMPLES;
+        int samplesPerCycle = round(SAMPLING_FREQ / freq);  // Use detected frequency, not hardcoded 50 Hz
+        int samplesToSend = WAVEFORM_EXPORT_PERIODS * samplesPerCycle + 1;
+        int maxSamplesToSend = SAMPLES;
+        if (samplesToSend > maxSamplesToSend) samplesToSend = maxSamplesToSend;
 
         for (int i = 0; i < samplesToSend; i++) {
             waveV_arr.add(round(waveformV_out[i] * 100) / 100.0);  // 2 decimals for voltage
             waveI_arr.add(round(waveformI_out[i] * 1000) / 1000.0);  // 3 decimals for current
         }
 
-        static char buffer[8192];  // Static (BSS) to avoid stack overflow; 3 cycles ≈ 3.5KB JSON
+        static char buffer[8192];  // Static (BSS) to avoid stack overflow with waveform arrays.
         size_t len = serializeJson(doc, buffer, sizeof(buffer));
         if (len >= sizeof(buffer)) {
             Serial.printf("[ERROR] JSON buffer overflow! Size: %d, Capacity: %d\n", len, sizeof(buffer));
@@ -355,16 +468,11 @@ void setup() {
   Serial.begin(115200);
   setup_wifi();
   client.setServer(MQTT_SERVER, 1883);
-  client.setBufferSize(8192);  // Increased to handle waveform arrays (128 samples × 2 × ~30 bytes)
+  client.setBufferSize(8192);  // Increased to handle waveform arrays.
 
-  analogReadResolution(12);
-  analogSetAttenuation(ADC_11db);
+  setup_adc_dma();
 
-  timer = timerBegin(0, 80, true);
-  timerAttachInterrupt(timer, &onTimer, true);
-  timerAlarmWrite(timer, 333, true);
-  timerAlarmEnable(timer);
-
+  xTaskCreatePinnedToCore(adcSamplingTask, "ADCSampling", 4096, NULL, 2, NULL, 0);
   xTaskCreatePinnedToCore(processingTask, "Proc", 15000, NULL, 1, NULL, 1);
 }
 

--- a/esp32-firmware/src/main.cpp
+++ b/esp32-firmware/src/main.cpp
@@ -474,10 +474,18 @@ void processingTask(void * pvParameters) {
         }
 
         static char buffer[8192];  // Static (BSS) to avoid stack overflow with waveform arrays.
-        size_t len = serializeJson(doc, buffer, sizeof(buffer));
-        if (len >= sizeof(buffer)) {
-            Serial.printf("[ERROR] JSON buffer overflow! Size: %d, Capacity: %d\n", len, sizeof(buffer));
+        size_t measuredLen = measureJson(doc);
+        if (measuredLen >= sizeof(buffer)) {
+            waveV_arr.clear();
+            waveI_arr.clear();
+            samplesToSend = 0;
+            measuredLen = measureJson(doc);
+        }
+
+        if (measuredLen >= sizeof(buffer)) {
+            Serial.printf("[ERROR] JSON payload too large! Size: %d, Capacity: %d\n", measuredLen, sizeof(buffer));
         } else {
+            size_t len = serializeJson(doc, buffer, sizeof(buffer));
             if (client.connected()) client.publish(MQTT_TOPIC, buffer);
             // Serial.println(buffer);  // Commented to reduce serial clutter - JSON sent via MQTT
             Serial.printf("[DATA] v=%.1fV i=%.3fA p=%.1fW f=%.1fHz%s (samples: %d, json: %d bytes)\n",

--- a/esp32-firmware/src/main.cpp
+++ b/esp32-firmware/src/main.cpp
@@ -35,6 +35,7 @@ const int MIN_ZERO_CROSSINGS = 2;           // Min 2 przejścia = 1 pełny okres
 volatile int rawBufferU[SAMPLES];
 volatile int rawBufferI[SAMPLES];
 volatile bool dataReady = false;
+portMUX_TYPE frameMux = portMUX_INITIALIZER_UNLOCKED;
 
 double vReal[SAMPLES], vImag[SAMPLES];
 double iReal[SAMPLES], iImag[SAMPLES];
@@ -114,19 +115,26 @@ void adcSamplingTask(void * pvParameters) {
     static int frameI[SAMPLES];
     int idxU = 0;
     int idxI = 0;
+    auto resetPartialFrame = [&]() {
+        idxU = 0;
+        idxI = 0;
+    };
 
     for (;;) {
         uint32_t bytesRead = 0;
         esp_err_t err = adc_digi_read_bytes(dmaBuffer, sizeof(dmaBuffer), &bytesRead, 1000);
         if (err == ESP_ERR_TIMEOUT) {
+            resetPartialFrame();
             continue;
         }
         if (err == ESP_ERR_INVALID_STATE) {
+            resetPartialFrame();
             Serial.println("[ADC-DMA] overflow: sampling faster than processing");
             vTaskDelay(pdMS_TO_TICKS(10));
             continue;
         }
         if (err != ESP_OK) {
+            resetPartialFrame();
             Serial.printf("[ADC-DMA] read failed: %d\n", err);
             vTaskDelay(pdMS_TO_TICKS(100));
             continue;
@@ -145,6 +153,7 @@ void adcSamplingTask(void * pvParameters) {
             }
 
             if (idxU >= SAMPLES && idxI >= SAMPLES) {
+                portENTER_CRITICAL(&frameMux);
                 if (!dataReady) {
                     for (int j = 0; j < SAMPLES; j++) {
                         rawBufferU[j] = frameU[j];
@@ -152,6 +161,7 @@ void adcSamplingTask(void * pvParameters) {
                     }
                     dataReady = true;
                 }
+                portEXIT_CRITICAL(&frameMux);
                 idxU = 0;
                 idxI = 0;
             }
@@ -241,17 +251,36 @@ float calculateFrequencyFromZeroCrossing(volatile int* rawBuffer, int numSamples
 }
 
 void processingTask(void * pvParameters) {
+  int *processingBufferU = (int *)malloc(SAMPLES * sizeof(int));
+  int *processingBufferI = (int *)malloc(SAMPLES * sizeof(int));
+  if (processingBufferU == nullptr || processingBufferI == nullptr) {
+    Serial.println("[ERROR] failed to allocate processing frame buffers");
+    while (true) vTaskDelay(pdMS_TO_TICKS(1000));
+  }
+
   for(;;) {
-    if (dataReady) {
-      unsigned long currentTime = millis();
-      if (currentTime - lastPublishTime >= 3000) {
+    unsigned long currentTime = millis();
+    if (currentTime - lastPublishTime >= 3000) {
+      bool frameReady = false;
+      portENTER_CRITICAL(&frameMux);
+      if (dataReady) {
+        for (int i = 0; i < SAMPLES; i++) {
+          processingBufferU[i] = rawBufferU[i];
+          processingBufferI[i] = rawBufferI[i];
+        }
+        dataReady = false;
+        frameReady = true;
+      }
+      portEXIT_CRITICAL(&frameMux);
+
+      if (frameReady) {
         lastPublishTime = currentTime;
 
         // 1. DC Offset i Wygładzanie (Oversampling programowy)
         double sumU = 0, sumI = 0;
-        for (int i = 0; i < SAMPLES; i++) { 
-            sumU += rawBufferU[i]; 
-            sumI += rawBufferI[i]; 
+        for (int i = 0; i < SAMPLES; i++) {
+            sumU += processingBufferU[i];
+            sumI += processingBufferI[i];
         }
         float offsetU = sumU / SAMPLES;
         float offsetI = sumI / SAMPLES;
@@ -260,8 +289,8 @@ void processingTask(void * pvParameters) {
         double sumU2 = 0, sumI2 = 0, sumP = 0;
 
         for (int i = 0; i < SAMPLES; i++) {
-            float uScaled = (rawBufferU[i] - offsetU) * vCoeff;
-            float iRaw = (float)rawBufferI[i] - offsetI;
+            float uScaled = (processingBufferU[i] - offsetU) * vCoeff;
+            float iRaw = (float)processingBufferI[i] - offsetI;
             float iDisplayScaled = iRaw * iCoeff;
             float iCalcRaw = iRaw;
             if (abs(iCalcRaw) < ADC_DEAD_ZONE) iCalcRaw = 0;
@@ -295,7 +324,7 @@ void processingTask(void * pvParameters) {
         float pActive = sumP / SAMPLES;
 
         // 3. Pomiar częstotliwości: Zero-crossing (primary) z FFT fallback
-        double freq = calculateFrequencyFromZeroCrossing((volatile int*)rawBufferU, SAMPLES, offsetU);
+        double freq = calculateFrequencyFromZeroCrossing(processingBufferU, SAMPLES, offsetU);
         bool freqFromZeroCrossing = (freq > 0.0);
 
         // Fallback na FFT jeśli zero-crossing zawiódł
@@ -313,8 +342,12 @@ void processingTask(void * pvParameters) {
         FFT.compute(vReal, vImag, SAMPLES, FFT_FORWARD);
         vReal[0] = 0;
 
-        int baseBin = round(freq / (SAMPLING_FREQ / (double)SAMPLES));
-        if (baseBin < 1) baseBin = 1;
+        double binWidth = SAMPLING_FREQ / (double)SAMPLES;
+        auto harmonicBin = [&](int h) {
+            int bin = round((freq * h) / binWidth);
+            return (bin < 1) ? 1 : bin;
+        };
+        int baseBin = harmonicBin(1);
 
         // Phase of fundamental H1 for voltage (before magnitude conversion)
         double phaseV_H1 = atan2(vImag[baseBin], vReal[baseBin]);
@@ -326,7 +359,7 @@ void processingTask(void * pvParameters) {
         double harmonicsV_out[MAX_CALC_HARMONIC + 1] = {0};
 
         for (int h = 1; h <= MAX_CALC_HARMONIC; h++) {
-            int bin = baseBin * h;
+            int bin = harmonicBin(h);
             double amp = (bin < SAMPLES/2) ? (vReal[bin] / SAMPLES) * 2.0 : 0;
             harmonicsV_out[h] = amp;
             if (h > 1) sumSqHarmonicsV += pow(amp, 2);
@@ -347,7 +380,7 @@ void processingTask(void * pvParameters) {
         double harmonicsI_out[MAX_CALC_HARMONIC + 1] = {0};
 
         for (int h = 1; h <= MAX_CALC_HARMONIC; h++) {
-            int bin = baseBin * h;
+            int bin = harmonicBin(h);
             double amp = (bin < SAMPLES/2) ? (iReal[bin] / SAMPLES) * 2.0 : 0;
             harmonicsI_out[h] = amp;
             if (h > 1) sumSqHarmonicsI += pow(amp, 2);
@@ -457,7 +490,6 @@ void processingTask(void * pvParameters) {
                           len);
         }
       }
-      dataReady = false; 
     }
     client.loop();
     vTaskDelay(pdMS_TO_TICKS(10)); 
@@ -468,7 +500,10 @@ void setup() {
   Serial.begin(115200);
   setup_wifi();
   client.setServer(MQTT_SERVER, 1883);
-  client.setBufferSize(8192);  // Increased to handle waveform arrays.
+  if (!client.setBufferSize(8192)) {  // Increased to handle waveform arrays.
+    Serial.println("[MQTT] failed to allocate 8192-byte packet buffer");
+    while (true) delay(1000);
+  }
 
   setup_adc_dma();
 

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/model/dto/MeasurementRequest.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/model/dto/MeasurementRequest.java
@@ -24,13 +24,13 @@ public class MeasurementRequest {
 
     @NotNull(message = "voltageRms is required")
     @DecimalMin(value = "0.0", message = "voltageRms must be non-negative")
-    @DecimalMax(value = "500.0", message = "voltageRms must not exceed 500V")
+    @DecimalMax(value = "500.0", message = "voltageRms must not exceed 500 V")
     @JsonProperty("v_rms")
     private Double voltageRms;
 
     @NotNull(message = "currentRms is required")
     @DecimalMin(value = "0.0", message = "currentRms must be non-negative")
-    @DecimalMax(value = "100.0", message = "currentRms must not exceed 100A")
+    @DecimalMax(value = "100.0", message = "currentRms must not exceed 100 A")
     @JsonProperty("i_rms")
     private Double currentRms;
 
@@ -63,8 +63,8 @@ public class MeasurementRequest {
     private Double powerFactor;
 
     @NotNull(message = "frequency is required")
-    @DecimalMin(value = "45.0", message = "frequency must be at least 45Hz")
-    @DecimalMax(value = "65.0", message = "frequency must not exceed 65Hz")
+    @DecimalMin(value = "45.0", message = "frequency must be at least 45 Hz")
+    @DecimalMax(value = "65.0", message = "frequency must not exceed 65 Hz")
     @JsonProperty("freq")
     private Double frequency;
 
@@ -85,14 +85,14 @@ public class MeasurementRequest {
     private Double[] harmonicsI;
 
     /**
-     * Raw voltage waveform samples (2 cycles, ~120 samples).
+     * Raw voltage waveform samples (2 cycles, about 400 samples at 50 Hz).
      * Optional - if not provided, frontend will reconstruct from harmonics.
      */
     @JsonProperty("waveform_v")
     private Double[] waveformV;
 
     /**
-     * Raw current waveform samples (2 cycles, ~120 samples).
+     * Raw current waveform samples (2 cycles, about 400 samples at 50 Hz).
      * Optional - if not provided, frontend will reconstruct from harmonics.
      */
     @JsonProperty("waveform_i")

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/model/dto/PowerQualityIndicatorsDTO.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/model/dto/PowerQualityIndicatorsDTO.java
@@ -37,7 +37,7 @@ public class PowerQualityIndicatorsDTO {
     private Double voltageRms;
 
     /**
-     * Voltage deviation from declared value (230V) in percent.
+     * Voltage deviation from declared value (230 V) in percent.
      * Formula: (U_measured - 230) / 230 * 100%
      * PN-EN 50160 limit: ±10% for 95% of week.
      */
@@ -72,7 +72,7 @@ public class PowerQualityIndicatorsDTO {
     /**
      * Total Harmonic Distortion of voltage in percent.
      * <p>
-     * IMPORTANT: Calculated from harmonics 2-8 only (partial measurement).
+     * IMPORTANT: Calculated from harmonics 2-25 only (partial measurement).
      * IEC 61000-4-7 requires harmonics 2-40 for full compliance.
      * This value represents a LOWER BOUND of actual THD.
      * <p>
@@ -82,14 +82,14 @@ public class PowerQualityIndicatorsDTO {
 
     /**
      * Flag indicating if THD is within PN-EN 50160 limit (<8%).
-     * Note: Based on partial THD (harmonics 2-8 only).
+     * Note: Based on partial THD (harmonics 2-25 only).
      */
     private Boolean thdWithinLimits;
 
     /**
      * Voltage harmonics array [H1, H2, H3, H4, H5, H6, H7,... H25].
      * <p>
-     * Limited to 8 harmonics due to Nyquist constraint at 800-1000 Hz sampling.
+     * Limited to H1-H25 by the current firmware payload.
      * IEC 61000-4-7 specifies measurement up to H40 for full compliance.
      */
     private Double[] harmonicsVoltage;

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/model/entity/Measurement.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/model/entity/Measurement.java
@@ -14,17 +14,17 @@ import org.hibernate.type.SqlTypes;
  * <p>
  * This entity stores both raw measurement values and calculated PN-EN 50160 power quality indicators.
  * The system is capable of measuring a subset of power quality parameters defined in PN-EN 50160
- * due to hardware limitations (12-bit ADC, 800-1000 Hz sampling rate).
+ * due to hardware limitations (ESP32 12-bit ADC and non-certified sensors).
  * <p>
  * Measurement capabilities:
  * - PN-EN 50160 Group 1: Supply voltage magnitude (voltage deviation)
  * - PN-EN 50160 Group 2: Supply frequency (frequency deviation)
- * - PN-EN 50160 Group 4: Voltage waveform distortions (THD and harmonics 2-8, partial)
+ * - PN-EN 50160 Group 4: Voltage waveform distortions (THD and harmonics 2-25, partial)
  * - Additional diagnostic parameters: power, power factor, current harmonics
  * <p>
  * Limitations:
- * - Harmonics limited to H1-H25 (50-400 Hz) due to Nyquist constraint at 800-1000 Hz sampling
- * - THD calculation is partial (excludes harmonics 9-40), representing lower bound of actual distortion
+ * - Harmonics reported as H1-H25 (50 Hz-1250 Hz)
+ * - THD calculation is partial (excludes harmonics 26-40), representing lower bound of actual distortion
  * - No flicker measurement (P_st/P_lt) - requires IEC 61000-4-15 compliant equipment
  * - Event detection (voltage dips, interruptions) implemented separately
  */
@@ -78,7 +78,7 @@ public class Measurement {
     private Double powerApparent;
 
     /**
-     * Reactive power of fundamental Q₁ in var (Budeanu theory, not a PN-EN 50160 indicator).
+     * Reactive power of fundamental Q₁ in VAr (Budeanu theory, not a PN-EN 50160 indicator).
      * <p>
      * Formula: Q₁ = U₁ * I₁ * sin(φ₁)
      * where φ₁ is the phase shift of fundamental (H1) only, extracted from FFT.
@@ -91,7 +91,7 @@ public class Measurement {
     private Double powerReactive;
 
     /**
-     * Distortion power D in var (Budeanu theory, not a PN-EN 50160 indicator).
+     * Distortion power D in VAr (Budeanu theory, not a PN-EN 50160 indicator).
      * <p>
      * Formula: D = sqrt(S² - P² - Q₁²)
      * <p>
@@ -132,12 +132,12 @@ public class Measurement {
     /**
      * Total Harmonic Distortion of voltage (PN-EN 50160 Group 4 indicator, partial).
      * <p>
-     * Formula: THD = sqrt(sum(U_h^2 for h=2..8)) / U_1 * 100%
+     * Formula: THD = sqrt(sum(U_h^2 for h=2..25)) / U_1 * 100%
      * <p>
      * IMPORTANT LIMITATIONS:
      * - IEC 61000-4-7 requires harmonics 2-40 for full compliance
-     * - Our system measures only harmonics 2-8 due to Nyquist limitation at 800-1000 Hz sampling
-     * - This represents a LOWER BOUND of actual THD (real THD may be higher due to unmeasured harmonics 9-40)
+     * - Our system reports harmonics 2-25
+     * - This represents a LOWER BOUND of actual THD (real THD may be higher due to unmeasured harmonics 26-40)
      * <p>
      * PN-EN 50160 limit: THD < 8% (for full spectrum 2-40)
      * <p>
@@ -148,9 +148,9 @@ public class Measurement {
     /**
      * Total Harmonic Distortion of current (diagnostic parameter, not PN-EN 50160 indicator).
      * <p>
-     * Formula: THD = sqrt(sum(I_h^2 for h=2..8)) / I_1 * 100%
+     * Formula: THD = sqrt(sum(I_h^2 for h=2..25)) / I_1 * 100%
      * <p>
-     * Note: Partial calculation, harmonics 2-8 only (same limitation as THD voltage).
+     * Note: Partial calculation, harmonics 2-25 only (same limitation as THD voltage).
      * Related to IEC 61000-3-2 (emission limits for equipment).
      * Used for diagnostics of non-linear loads.
      * <p>
@@ -159,7 +159,7 @@ public class Measurement {
     private Double thdCurrent;
 
     /**
-     * Voltage harmonics array containing 8 values (PN-EN 50160 Group 4 indicator, partial).
+     * Voltage harmonics array containing 25 values (PN-EN 50160 Group 4 indicator, partial).
      * <p>
      * Array structure:
      * - harmonicsV[0] = H1 (50 Hz fundamental component)
@@ -175,12 +175,13 @@ public class Measurement {
      * .
      * - harmonicsV[24] = H25 (1250 Hz, 25th harmonic)
      * <p>
-     * NYQUIST LIMITATION:
-     * At 800-1000 Hz sampling rate, Nyquist frequency is 400-500 Hz.
-     * Harmonics above 25th order cannot be reliably measured (aliasing).
+     * RANGE LIMITATION:
+     * Firmware reports harmonics up to the 25th order. At 10 kHz per channel,
+     * Nyquist frequency is 5 kHz, so H25 is an implementation/reporting limit,
+     * not the ADC Nyquist limit.
      * <p>
      * IEC 61000-4-7 specifies measurement up to 40th harmonic (2000 Hz) for full compliance.
-     * Our system measures only up to 25th harmonic due to hardware sampling constraints.
+     * Our system reports up to 25th harmonic in the current firmware payload.
      * <p>
      * Calculated by ESP32 from FFT/DFT with Hann window and zero-crossing synchronization.
      */
@@ -189,14 +190,14 @@ public class Measurement {
     private Double[] harmonicsV;
 
     /**
-     * Current harmonics array containing 8 values (diagnostic parameter, not PN-EN 50160 indicator).
+     * Current harmonics array containing 25 values (diagnostic parameter, not PN-EN 50160 indicator).
      * <p>
      * Array structure: Same as harmonicsV (H1-H25).
      * <p>
      * Related to IEC 61000-3-2 (emission limits for equipment).
      * Used for diagnostics of non-linear loads (switch-mode power supplies, inverters, LED drivers).
      * <p>
-     * Note: Limited to 8 harmonics due to same Nyquist constraint as voltage harmonics.
+     * Note: Limited to the same H1-H25 reporting range as voltage harmonics.
      * <p>
      * Calculated by ESP32 from FFT/DFT.
      */
@@ -205,7 +206,7 @@ public class Measurement {
     private Double[] harmonicsI;
 
     /**
-     * Raw voltage waveform samples from ESP32 (2 cycles, ~120 samples at 50Hz).
+     * Raw voltage waveform samples from ESP32 (2 cycles, about 400 samples at 50 Hz).
      * <p>
      * Contains actual sampled voltage values BEFORE FFT processing.
      * Used for accurate waveform visualization showing real distortions, clipping, asymmetry.
@@ -217,7 +218,7 @@ public class Measurement {
     private Double[] waveformV;
 
     /**
-     * Raw current waveform samples from ESP32 (2 cycles, ~120 samples at 50Hz).
+     * Raw current waveform samples from ESP32 (2 cycles, about 400 samples at 50 Hz).
      * <p>
      * Contains actual sampled current values BEFORE FFT processing.
      * Used for accurate waveform visualization showing real distortions, clipping, asymmetry.
@@ -232,10 +233,10 @@ public class Measurement {
      * PN-EN 50160 Group 1 indicator: Voltage deviation from declared value.
      * <p>
      * Formula: (U_measured - U_nominal) / U_nominal * 100%
-     * where U_nominal = 230V for single-phase EU grid.
+     * where U_nominal = 230 V for single-phase EU grid.
      * <p>
      * PN-EN 50160 limit: ±10% for 95% of week.
-     * Acceptable range: 207-253 V for 230V nominal.
+     * Acceptable range: 207-253 V for 230 V nominal.
      * <p>
      * Calculated by backend from voltageRms.
      */

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
@@ -82,7 +82,7 @@ public class MeasurementService {
      * Calculates PN-EN 50160 power quality indicators from raw measurement data.
      * <p>
      * This method computes voltage and frequency deviations according to PN-EN 50160 standard:
-     * - Group 1: Voltage deviation from declared value (230V nominal)
+     * - Group 1: Voltage deviation from declared value (230 V nominal)
      * - Group 2: Frequency deviation from nominal (50 Hz)
      * <p>
      * WHY IN SERVICE LAYER:
@@ -100,7 +100,7 @@ public class MeasurementService {
             double deviation = ((measurement.getVoltageRms() - Constants.NOMINAL_VOLTAGE)
                     / Constants.NOMINAL_VOLTAGE) * 100.0;
             measurement.setVoltageDeviationPercent(deviation);
-            log.debug("Calculated voltage deviation: {}% (U_rms={}V)",
+            log.debug("Calculated voltage deviation: {}% (U_rms={} V)",
                     String.format("%.2f", deviation), measurement.getVoltageRms());
         }
 
@@ -109,7 +109,7 @@ public class MeasurementService {
         if (measurement.getFrequency() != null) {
             double deviation = measurement.getFrequency() - Constants.NOMINAL_FREQUENCY;
             measurement.setFrequencyDeviationHz(deviation);
-            log.debug("Calculated frequency deviation: {} Hz (f={}Hz)",
+            log.debug("Calculated frequency deviation: {} Hz (f={} Hz)",
                     String.format("%.3f", deviation), measurement.getFrequency());
         }
 
@@ -339,7 +339,7 @@ public class MeasurementService {
 
     /**
      * Check if THD is within PN-EN 50160 limit (<8%).
-     * Note: Our THD is partial (harmonics 2-8 only), representing lower bound.
+     * Note: Our THD is partial (harmonics 2-25 only), representing lower bound.
      */
     private Boolean checkThdCompliance(Double thdVoltage) {
         if (thdVoltage == null) {

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementValidator.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementValidator.java
@@ -44,21 +44,21 @@ public class MeasurementValidator {
         double apparentPowerFromUI = voltageRms * currentRms;
 
         if (voltageRms > 360.0) {
-            errors.add("Błąd krytyczny: Napięcie " + voltageRms + "V przekracza próg bezpieczeństwa (360V).");
+            errors.add("Błąd krytyczny: Napięcie " + voltageRms + " V przekracza próg bezpieczeństwa (360 V).");
         } else if (voltageRms < Constants.NOMINAL_VOLTAGE * (1 - Constants.VOLTAGE_TOLERANCE) ||
                 voltageRms > Constants.NOMINAL_VOLTAGE * (1 + Constants.VOLTAGE_TOLERANCE)) {
-            warnings.add("Ostrzeżenie: Napięcie " + voltageRms + "V poza normą PN-EN 50160.");
+            warnings.add("Ostrzeżenie: Napięcie " + voltageRms + " V poza normą PN-EN 50160.");
         }
 
         if (currentRms > 40.0) {
-            errors.add("Błąd krytyczny: Prąd " + currentRms + "A przekracza próg bezpieczeństwa (40A).");
+            errors.add("Błąd krytyczny: Prąd " + currentRms + " A przekracza próg bezpieczeństwa (40 A).");
         }
         
         if (frequency < 45.0 || frequency > 55.0) {
-            errors.add("Błąd krytyczny: Częstotliwość " + frequency + "Hz poza bezpiecznym zakresem (45-55Hz).");
+            errors.add("Błąd krytyczny: Częstotliwość " + frequency + " Hz poza bezpiecznym zakresem (45-55 Hz).");
         } else if (frequency < Constants.FREQUENCY_MIN || 
                    frequency > Constants.FREQUENCY_MAX) {
-            warnings.add("Ostrzeżenie: Częstotliwość " + frequency + "Hz poza normą PN-EN 50160.");
+            warnings.add("Ostrzeżenie: Częstotliwość " + frequency + " Hz poza normą PN-EN 50160.");
         }
         
         if (powerFactor < Constants.MIN_POWER_FACTOR) {

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/WaveformService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/WaveformService.java
@@ -20,7 +20,7 @@ public class WaveformService {
      * V(t) = H₁·sin(ω₁·t) + H₂·sin(ω₂·t) + ... + H₂₅·sin(ω₂₅·t)
      *
      * @param harmonics       harmonic amplitudes [H1=fundamental, H2=2nd, ..., H25=25th]
-     * @param frequency       fundamental frequency in Hz (50Hz for EU)
+     * @param frequency       fundamental frequency in Hz (50 Hz for EU)
      * @param samplesPerCycle number of samples per cycle (200 for smooth graph)
      * @param phaseShift      phase shift in radians (arccos(cosPhi) for current)
      * @return waveform samples for one complete cycle

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/Constants.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/Constants.java
@@ -12,7 +12,7 @@ package com.dkowalczyk.scadasystem.util;
  * - Power factor thresholds
  * <p>
  * Note: Some limits reference full harmonic spectrum (2-40) per IEC standards,
- * but our system measures only harmonics 2-8 due to hardware sampling constraints.
+ * but our system currently reports harmonics 2-25.
  */
 public final class Constants {
 
@@ -69,9 +69,9 @@ public final class Constants {
      * THD voltage limit per PN-EN 50160 and IEC 61000-4-7.
      * Applies to full harmonic spectrum (harmonics 2-40).
      * <p>
-     * IMPORTANT: Our system measures only harmonics 2-8 due to Nyquist limitation
-     * at 800-1000 Hz sampling rate. Calculated THD represents a LOWER BOUND of
-     * actual distortion (real THD may be higher due to unmeasured harmonics 9-40).
+     * IMPORTANT: Our system reports harmonics 2-25. Calculated THD represents a
+     * LOWER BOUND of actual distortion (real THD may be higher due to unmeasured
+     * harmonics 26-40).
      */
     public static final double VOLTAGE_THD_LIMIT = 8.0;
 
@@ -81,7 +81,7 @@ public final class Constants {
      * <p>
      * Note: This is a diagnostic parameter, not a PN-EN 50160 indicator.
      * PN-EN 50160 focuses on voltage quality, not current.
-     * Our system measures only harmonics 2-8 (partial THD).
+     * Our system reports harmonics 2-25 (partial THD).
      */
     public static final double CURRENT_THD_LIMIT = 5.0;
     /**
@@ -143,17 +143,16 @@ public final class Constants {
     // === Power Factor (Not a PN-EN 50160 indicator) ===
     /**
      * Number of harmonics measured by the system.
-     * Limited by Nyquist constraint at 800-1000 Hz sampling rate.
-     * Includes fundamental (H1) + harmonics 2-8.
+     * Includes fundamental (H1) + harmonics 2-25.
      */
     public static final int HARMONICS_COUNT = 25;
 
     // === Measurement System Specifications ===
     /**
-     * Sampling rate of ESP32 ADC (Hz).
-     * Conservative value with WiFi enabled.
+     * Sampling rate of ESP32 ADC per channel (Hz).
+     * Firmware uses ADC continuous DMA mode.
      */
-    public static final int SAMPLING_RATE_HZ = 3000;
+    public static final int SAMPLING_RATE_HZ = 10000;
     /**
      * Nyquist frequency: maximum measurable frequency (Hz).
      * Nyquist = sampling_rate / 2.
@@ -161,7 +160,7 @@ public final class Constants {
     public static final int NYQUIST_FREQUENCY_HZ = SAMPLING_RATE_HZ / 2;
     /**
      * Maximum measurable harmonic order at current sampling rate.
-     * 1500 Hz / 50 Hz = 30th harmonic.
+     * 5000 Hz / 50 Hz = 100th harmonic.
      */
     public static final int MAX_HARMONIC_ORDER = NYQUIST_FREQUENCY_HZ / (int) NOMINAL_FREQUENCY;
 

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/MathUtils.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/MathUtils.java
@@ -103,23 +103,23 @@ public class MathUtils {
      * <p>
      * Mathematical formula: V(t) = Σ[Hₙ · sin(ωₙ · t)] where ωₙ = 2π · f · n
      * <p>
-     * WHY: ESP32 sends harmonic amplitudes (8 numbers) to save bandwidth.
-     * This function reconstructs the full waveform (200 samples) for visualization.
+     * WHY: ESP32 sends harmonic amplitudes to save bandwidth.
+     * This function reconstructs a waveform for visualization.
      *
      * @param harmonics       Array of harmonic amplitudes [H1, H2, ..., H25]
      *                        H1 = fundamental frequency, H2 = 2nd harmonic, etc.
-     * @param frequency       Fundamental frequency in Hz (50Hz for EU, 60Hz for
+     * @param frequency       Fundamental frequency in Hz (50 Hz for EU, 60 Hz for
      *                        USA)
      * @param samplesPerCycle Number of samples to generate per complete cycle
      * @return Array of waveform samples representing one complete cycle, or zeros
      *         if harmonics is null/empty
      *         <p>
      *         EXAMPLE:
-     *         harmonics = [230.0, 4.8, 2.3, 1.1, 0.8, 0.5, 0.3, 0.2]
+     *         harmonics = [230.0, 4.8, 2.3, 1.1, 0.8, 0.5, 0.3, 0.2, ...]
      *         frequency = 50.0
      *         samplesPerCycle = 200
-     *         → returns 200-element array representing voltage waveform over 20ms
-     *         (one 50Hz cycle)
+     *         -> returns samples representing voltage waveform over one cycle
+     *         (20 ms at 50 Hz)
      */
     public static double[] reconstructWaveform(Double[] harmonics, double frequency, int samplesPerCycle,
             double phaseShift) {
@@ -154,7 +154,7 @@ public class MathUtils {
 
     /**
      * Calculate apparent power S (in VA) from active power P (in W) and reactive
-     * power Q (in VAR).
+     * power Q (in VAr).
      * Formula: S = √(P² + Q²)
      */
     public static double calculateApparentPower(double activePower, double reactivePower) {

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/MathUtils.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/util/MathUtils.java
@@ -129,10 +129,10 @@ public class MathUtils {
 
         double[] waveform = new double[samplesPerCycle];
 
-        // t_step = 1.0 / (frequency * samplesPerCycle);
+        double secondsPerSample = 1.0 / (frequency * samplesPerCycle);
 
         for (int i = 0; i < samplesPerCycle; i++) {
-            double t = (double) i / samplesPerCycle;
+            double t = i * secondsPerSample;
             double sum = 0;
 
             for (int h = 0; h < harmonics.length; h++) {
@@ -143,7 +143,8 @@ public class MathUtils {
                 double amplitude = harmonics[h] * Math.sqrt(2);
 
                 // Fourier Synthesis:
-                double angle = 2.0 * Math.PI * harmonicOrder * t - (harmonicOrder == 1 ? phaseShift : 0);
+                double angle = 2.0 * Math.PI * frequency * harmonicOrder * t
+                        - (harmonicOrder == 1 ? phaseShift : 0);
                 sum += amplitude * Math.sin(angle);
             }
             waveform[i] = sum;

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/controller/DashboardControllerTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/controller/DashboardControllerTest.java
@@ -317,7 +317,7 @@ class DashboardControllerTest extends BaseControllerTest {
         @Test
         @DisplayName("should handle edge case: voltage at exact -10% limit")
         void shouldHandleVoltageAtExactNegativeLimit() throws Exception {
-            // Given: Voltage exactly at -10% limit (207V)
+            // Given: Voltage exactly at -10% limit (207 V)
             PowerQualityIndicatorsDTO atLimit = PowerQualityIndicatorsDTO.builder()
                     .timestamp(Instant.now())
                     .voltageRms(207.0)
@@ -344,7 +344,7 @@ class DashboardControllerTest extends BaseControllerTest {
         @Test
         @DisplayName("should handle edge case: frequency at exact +0.5Hz limit")
         void shouldHandleFrequencyAtExactPositiveLimit() throws Exception {
-            // Given: Frequency exactly at +0.5Hz limit (50.5Hz)
+            // Given: Frequency exactly at +0.5 Hz limit (50.5 Hz)
             PowerQualityIndicatorsDTO atLimit = PowerQualityIndicatorsDTO.builder()
                     .timestamp(Instant.now())
                     .voltageRms(230.0)

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/exception/GlobalExceptionHandlerTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/exception/GlobalExceptionHandlerTest.java
@@ -213,7 +213,7 @@ class GlobalExceptionHandlerTest extends BaseIntegrationTest {
         @Test
         @DisplayName("should return 400 when field violates constraint")
         void shouldReturn400_whenConstraintViolated() throws Exception {
-            // Given: Voltage exceeds max (500V)
+            // Given: Voltage exceeds max (500 V)
             MeasurementRequest request = createValidRequest();
             request.setVoltageRms(600.0);
 

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementValidatorTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementValidatorTest.java
@@ -32,7 +32,7 @@ public class MeasurementValidatorTest {
 
         // THEN
         assertFalse(result.isValid());
-        assertTrue(result.getErrors().stream().anyMatch(e -> e.contains("360V")));
+        assertTrue(result.getErrors().stream().anyMatch(e -> e.contains("360 V")));
     }
 
     @Test

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
@@ -298,7 +298,7 @@ class StatsServiceTest {
     @Test
     @DisplayName("calculateDailyStats() should count voltage swell events correctly with duration")
     void calculateDailyStats_shouldCountVoltageSwells_correctly() {
-        // Given: One continuous voltage swell event (> 253V = 110% of 230V)
+        // Given: One continuous voltage swell event (> 253 V = 110% of 230 V)
         // Event: swell at t=3s, 6s (duration = 3s) -> counts as 1 event
         List<Measurement> measurements = List.of(
                 createMeasurement(testDate, 0, 230.0, 1000.0, 50.0, 0.95, 5.0),  // Normal
@@ -320,7 +320,7 @@ class StatsServiceTest {
     @Test
     @DisplayName("calculateDailyStats() should count interruption events correctly with duration")
     void calculateDailyStats_shouldCountInterruptions_correctly() {
-        // Given: One continuous interruption event (< 23V = 10% of 230V, duration > 0.01s)
+        // Given: One continuous interruption event (< 23 V = 10% of 230 V, duration > 0.01 s)
         // Event: interruption at t=3s, 6s (duration = 3s) -> counts as 1 event
         List<Measurement> measurements = List.of(
                 createMeasurement(testDate, 0, 230.0, 1000.0, 50.0, 0.95, 5.0),  // Normal

--- a/scada-system/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/scada-system/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass

--- a/webapp/src/components/HarmonicsChart.tsx
+++ b/webapp/src/components/HarmonicsChart.tsx
@@ -48,8 +48,8 @@ export const HarmonicsChart = forwardRef<
   // Transform harmonics arrays into Recharts format with memoization
   // Memoized to prevent unnecessary recalculations on every render
   // harmonicsVoltage = [H1, H2, H3, ..., H25]
-  // H1 = fundamental (50Hz), H2 = 2nd harmonic (100Hz), etc.
-  // Limited to H1-H25 (50Hz-1250Hz) due to Nyquist constraint at 3000Hz sampling rate
+  // H1 = fundamental (50 Hz), H2 = 2nd harmonic (100 Hz), etc.
+  // Firmware reports H1-H25 (50 Hz-1250 Hz); Nyquist at 10 kHz sampling is 5 kHz.
   const chartData = useMemo(() => {
     return harmonicsVoltage.map((vHarmonic, index) => {
       const currentValue = harmonicsCurrent[index];
@@ -133,12 +133,12 @@ export const HarmonicsChart = forwardRef<
           <div className="flex items-start gap-2 bg-yellow-500/10 border border-yellow-500/20 rounded-md p-2">
             <Info className="w-4 h-4 text-yellow-600 flex-shrink-0 mt-0.5" />
             <p className="text-xs text-yellow-700 dark:text-yellow-400">
-              <strong>Ograniczenie Nyquista:</strong> System próbkuje przy
-              3000Hz (512 próbek), co pozwala na pomiar harmonicznych H1-H25
-              (50Hz-1250Hz). THD jest obliczane z H2-H25 zamiast pełnego zakresu
-              H2-H40 wymaganego przez IEC 61000-4-7. Wyświetlana wartość
-              reprezentuje <strong>dolne ograniczenie</strong> rzeczywistego THD
-              (brakuje H26-H40).
+              <strong>Ograniczenie zakresu harmonicznych:</strong> System
+              próbkuje przy 10 kHz i raportuje harmoniczne H1-H25 (50 Hz-1250
+              Hz). THD jest obliczane z H2-H25 zamiast pełnego zakresu H2-H40
+              wymaganego przez IEC 61000-4-7. Wyświetlana wartość reprezentuje{" "}
+              <strong>dolne ograniczenie</strong> rzeczywistego THD (brakuje
+              H26-H40).
             </p>
           </div>
         </div>

--- a/webapp/src/components/PowerQualitySection.tsx
+++ b/webapp/src/components/PowerQualitySection.tsx
@@ -11,8 +11,8 @@ interface PowerQualitySectionProps {
  * Component displaying PN-EN 50160 power quality indicators.
  *
  * Shows standardized power quality metrics:
- * - Group 1: Voltage deviation from 230V (±10% limit)
- * - Group 2: Frequency deviation from 50Hz (±0.5Hz limit)
+ * - Group 1: Voltage deviation from 230 V (±10% limit)
+ * - Group 2: Frequency deviation from 50 Hz (±0.5 Hz limit)
  * - Group 4: THD voltage (8% limit, partial measurement warning)
  *
  * Each indicator shows:
@@ -107,8 +107,8 @@ export function PowerQualitySection({ data }: PowerQualitySectionProps) {
               Ograniczenia pomiarowe
             </h4>
             <p className="text-sm text-yellow-700 dark:text-yellow-400 mt-1">
-              THD obliczane tylko z harmonicznych H2-H25 (ograniczenie Nyquista
-              przy 3000Hz). Wartość reprezentuje{" "}
+              THD obliczane tylko z harmonicznych H2-H25 (zakres raportowany
+              przez firmware przy próbkowaniu 10 kHz). Wartość reprezentuje{" "}
               <strong>dolne ograniczenie</strong> rzeczywistego THD. Pełna norma
               IEC 61000-4-7 wymaga harmonicznych H2-H40.
             </p>
@@ -149,11 +149,11 @@ export function PowerQualitySection({ data }: PowerQualitySectionProps) {
                 </div>
               </div>
               <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">Limit: 230V ±10%</span>
+                <span className="text-muted-foreground">Limit: 230 V ±10%</span>
                 {getComplianceBadge(data.voltage_within_limits)}
               </div>
               <div className="text-xs text-muted-foreground">
-                Zakres: 207V - 253V
+                Zakres: 207 V - 253 V
               </div>
             </div>
           </div>
@@ -192,12 +192,12 @@ export function PowerQualitySection({ data }: PowerQualitySectionProps) {
               </div>
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">
-                  Limit: 50Hz ±0.5Hz
+                  Limit: 50 Hz ±0.5 Hz
                 </span>
                 {getComplianceBadge(data.frequency_within_limits)}
               </div>
               <div className="text-xs text-muted-foreground">
-                Zakres: 49.5Hz - 50.5Hz
+                Zakres: 49.5 Hz - 50.5 Hz
               </div>
             </div>
           </div>

--- a/webapp/src/components/WaveformChart.tsx
+++ b/webapp/src/components/WaveformChart.tsx
@@ -87,6 +87,21 @@ function trimToExactPeriods(
   };
 }
 
+function useRawPeriodsFallback(
+  voltage: number[],
+  current: number[],
+  frequency: number,
+  numPeriods: number
+): { voltage: number[]; current: number[]; samplingRate: number } | null {
+  if (voltage.length < 2 || voltage.length !== current.length) return null;
+
+  return {
+    voltage,
+    current,
+    samplingRate: ((voltage.length - 1) * frequency) / numPeriods,
+  };
+}
+
 export function WaveformChart({ waveforms, frequency }: WaveformChartProps) {
   const [numPeriods, setNumPeriods] = useState<1 | 2>(1);
 
@@ -103,15 +118,26 @@ export function WaveformChart({ waveforms, frequency }: WaveformChartProps) {
     );
   }
 
-  // Try to trim to exact periods; fallback to 1 period, then raw data
+  // Try to trim to exact periods. If 2T cannot be trimmed because the ESP32
+  // buffer starts mid-period, show the raw two-period payload instead.
   const trimmedRequested = trimToExactPeriods(
     waveforms.voltage,
     waveforms.current,
     frequency,
     numPeriods,
   );
+  const rawPeriodsFallback =
+    numPeriods === 2
+      ? useRawPeriodsFallback(
+          waveforms.voltage,
+          waveforms.current,
+          frequency,
+          numPeriods,
+        )
+      : null;
   const trimmedFallback =
     trimmedRequested ??
+    rawPeriodsFallback ??
     trimToExactPeriods(waveforms.voltage, waveforms.current, frequency, 1);
   const trimmed = trimmedFallback;
 

--- a/webapp/src/components/WaveformChart.tsx
+++ b/webapp/src/components/WaveformChart.tsx
@@ -87,7 +87,7 @@ function trimToExactPeriods(
   };
 }
 
-function useRawPeriodsFallback(
+function getRawPeriodsFallback(
   voltage: number[],
   current: number[],
   frequency: number,
@@ -128,7 +128,7 @@ export function WaveformChart({ waveforms, frequency }: WaveformChartProps) {
   );
   const rawPeriodsFallback =
     numPeriods === 2
-      ? useRawPeriodsFallback(
+      ? getRawPeriodsFallback(
           waveforms.voltage,
           waveforms.current,
           frequency,
@@ -138,7 +138,9 @@ export function WaveformChart({ waveforms, frequency }: WaveformChartProps) {
   const trimmedFallback =
     trimmedRequested ??
     rawPeriodsFallback ??
-    trimToExactPeriods(waveforms.voltage, waveforms.current, frequency, 1);
+    (numPeriods === 1
+      ? null
+      : trimToExactPeriods(waveforms.voltage, waveforms.current, frequency, 1));
   const trimmed = trimmedFallback;
 
   const displayVoltage = trimmed ? trimmed.voltage : waveforms.voltage;

--- a/webapp/src/components/WaveformChart.tsx
+++ b/webapp/src/components/WaveformChart.tsx
@@ -18,6 +18,8 @@ interface WaveformChartProps {
   frequency: number;
 }
 
+const RAW_WAVEFORM_PERIODS = 2;
+
 /**
  * Generate symmetric tick values around zero.
  * Picks a "nice" step (1, 2, 2.5, 5 × 10^n) and returns ticks from -max to +max.
@@ -126,15 +128,12 @@ export function WaveformChart({ waveforms, frequency }: WaveformChartProps) {
     frequency,
     numPeriods,
   );
-  const rawPeriodsFallback =
-    numPeriods === 2
-      ? getRawPeriodsFallback(
-          waveforms.voltage,
-          waveforms.current,
-          frequency,
-          numPeriods,
-        )
-      : null;
+  const rawPeriodsFallback = getRawPeriodsFallback(
+    waveforms.voltage,
+    waveforms.current,
+    frequency,
+    RAW_WAVEFORM_PERIODS,
+  );
   const trimmedFallback =
     trimmedRequested ??
     rawPeriodsFallback ??

--- a/webapp/src/components/WaveformChart.tsx
+++ b/webapp/src/components/WaveformChart.tsx
@@ -18,8 +18,6 @@ interface WaveformChartProps {
   frequency: number;
 }
 
-const RAW_WAVEFORM_PERIODS = 2;
-
 /**
  * Generate symmetric tick values around zero.
  * Picks a "nice" step (1, 2, 2.5, 5 × 10^n) and returns ticks from -max to +max.
@@ -56,6 +54,24 @@ function findPositiveZeroCrossings(data: number[]): number[] {
     }
   }
   return crossings;
+}
+
+function estimateRawPeriods(voltage: number[]): number {
+  if (voltage.length < 2) return 1;
+
+  let zeroCrossings = 0;
+  if (voltage[0] === 0 || voltage[0] * voltage[1] < 0) {
+    zeroCrossings++;
+  }
+
+  for (let i = 1; i < voltage.length; i++) {
+    if (voltage[i - 1] === 0) continue;
+    if (voltage[i] === 0 || voltage[i - 1] * voltage[i] < 0) {
+      zeroCrossings++;
+    }
+  }
+
+  return Math.max(1, Math.round(zeroCrossings / 2));
 }
 
 /**
@@ -132,7 +148,7 @@ export function WaveformChart({ waveforms, frequency }: WaveformChartProps) {
     waveforms.voltage,
     waveforms.current,
     frequency,
-    RAW_WAVEFORM_PERIODS,
+    estimateRawPeriods(waveforms.voltage),
   );
   const trimmedFallback =
     trimmedRequested ??

--- a/webapp/src/hooks/useWebSocket.ts
+++ b/webapp/src/hooks/useWebSocket.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
-import type { RealtimeDashboardDTO } from '@/types/api';
+import type { DashboardDTO, RealtimeDashboardDTO } from '@/types/api';
 
 interface UseWebSocketOptions {
   url: string;
@@ -26,8 +26,7 @@ interface UseWebSocketOptions {
  *
  * Backend sends RealtimeDashboardDTO every 3 seconds with:
  * - latest_measurement (voltage, current, power, THD, harmonics)
- * - waveforms (200 samples of voltage/current sinusoid)
- * - recent_history (last N measurements)
+ * - waveforms (two periods of voltage/current samples)
  */
 export function useWebSocket({
   url,
@@ -65,8 +64,15 @@ export function useWebSocket({
             // Update local state for streaming components
             setLatestData(data);
 
-            // Update React Query cache automatically
-            queryClient.setQueryData(['dashboard'], data);
+            // Update React Query cache while preserving the full DashboardDTO shape.
+            queryClient.setQueryData<DashboardDTO | undefined>(
+              ['dashboard'],
+              (previous) => ({
+                latest_measurement: data.latest_measurement,
+                waveforms: data.waveforms,
+                recent_history: previous?.recent_history ?? [],
+              }),
+            );
 
             // Call custom handler if provided
             onMessageRef.current?.(data);

--- a/webapp/src/lib/constants.ts
+++ b/webapp/src/lib/constants.ts
@@ -3,18 +3,18 @@
  * Must match backend Constants.java for consistency.
  */
 export const POWER_QUALITY_LIMITS = Object.freeze({
-  // Voltage limits (PN-EN 50160: 230V ±10%)
+  // Voltage limits (PN-EN 50160: 230 V ±10%)
   NOMINAL_VOLTAGE: 230.0,
-  VOLTAGE_MIN: 207.0,  // 230V - 10%
-  VOLTAGE_MAX: 253.0,  // 230V + 10%
+  VOLTAGE_MIN: 207.0,  // 230 V - 10%
+  VOLTAGE_MAX: 253.0,  // 230 V + 10%
 
-  // Frequency limits (PN-EN 50160: 50Hz ±1%)
+  // Frequency limits (PN-EN 50160: 50 Hz ±1%)
   NOMINAL_FREQUENCY: 50.0,
-  FREQUENCY_MIN: 49.5,  // 50Hz - 1%
-  FREQUENCY_MAX: 50.5,  // 50Hz + 1%
+  FREQUENCY_MIN: 49.5,  // 50 Hz - 1%
+  FREQUENCY_MAX: 50.5,  // 50 Hz + 1%
 
-  // Current limits (typical household 16A circuit)
-  CURRENT_WARNING: 13.0,   // 80% of 16A rated
+  // Current limits (typical household 16 A circuit)
+  CURRENT_WARNING: 13.0,   // 80% of 16 A rated
   CURRENT_CRITICAL: 16.0,  // Circuit breaker rating
 
   // THD limits (IEC 61000-4-7 and IEC 61000-3-2)
@@ -22,5 +22,5 @@ export const POWER_QUALITY_LIMITS = Object.freeze({
   CURRENT_THD_LIMIT: 5.0,  // IEC 61000-3-2 emission limit
 
   // Power factor (typical contractual requirement)
-  MIN_POWER_FACTOR: 0.85,  // Minimum acceptable cos φ
+  MIN_POWER_FACTOR: 0.85,  // Minimum acceptable λ = P/S
 });

--- a/webapp/src/test/components/HarmonicsChart.test.tsx
+++ b/webapp/src/test/components/HarmonicsChart.test.tsx
@@ -78,7 +78,7 @@ vi.mock('recharts', () => ({
 }));
 
 describe('HarmonicsChart Component - Comprehensive Suite', () => {
-  // H1-H25 (25 harmonics measured at 3000Hz sampling rate)
+  // H1-H25 (25 harmonics reported by firmware at 10 kHz sampling rate)
   const harmonicsVoltage = [
     230.0, 8.5, 6.2, 4.1, 2.3, 1.1, 0.5, 0.2, // H1-H25
     0.15, 0.12, 0.09, 0.07, 0.06, 0.05, 0.04, 0.03, // H9-H16
@@ -103,10 +103,10 @@ describe('HarmonicsChart Component - Comprehensive Suite', () => {
       expect(screen.getByTestId('responsive-container')).toBeInTheDocument();
     });
 
-    it('renders the technical Info box explaining Nyquist limit', () => {
+    it('renders the technical Info box explaining harmonic range limit', () => {
       render(React.createElement(HarmonicsChart, defaultProps));
-      expect(screen.getByText(/Ograniczenie Nyquista/i)).toBeInTheDocument();
-      expect(screen.getByText(/3000Hz/i)).toBeInTheDocument();
+      expect(screen.getByText(/Ograniczenie zakresu harmonicznych/i)).toBeInTheDocument();
+      expect(screen.getByText(/10 kHz/i)).toBeInTheDocument();
     });
 
     it('renders THD values with exactly 2 decimal places', () => {
@@ -118,7 +118,7 @@ describe('HarmonicsChart Component - Comprehensive Suite', () => {
   });
 
   describe('Data Mapping & Logic', () => {
-    it('correctly maps frequency values (50Hz steps) to chart data', () => {
+    it('correctly maps frequency values (50 Hz steps) to chart data', () => {
       render(React.createElement(HarmonicsChart, defaultProps));
       const chart = screen.getByTestId('bar-chart');
       const data = JSON.parse(chart.getAttribute('data-raw') || '[]');

--- a/webapp/src/test/components/WaveformChart.test.tsx
+++ b/webapp/src/test/components/WaveformChart.test.tsx
@@ -275,7 +275,7 @@ describe('WaveformChart - Comprehensive Suite', () => {
 
       const voltageAxis = screen.getByTestId('y-axis-v-axis');
 
-      // Domain is now rounded to nice symmetric tick values (e.g. [-300,300] for max ~230V)
+      // Domain is now rounded to nice symmetric tick values (e.g. [-300,300] for max ~230 V)
       const domain = JSON.parse(voltageAxis.getAttribute('data-domain')!) as [number, number];
       expect(voltageAxis).toHaveAttribute('data-orientation', 'left');
       expect(domain[0]).toBeLessThan(0);
@@ -288,7 +288,7 @@ describe('WaveformChart - Comprehensive Suite', () => {
       const currentAxis = screen.getByTestId('y-axis-i-axis');
       expect(currentAxis).toHaveAttribute('data-orientation', 'right');
 
-      // Domain is now rounded to nice symmetric tick values (e.g. [-20,20] for max ~15A)
+      // Domain is now rounded to nice symmetric tick values (e.g. [-20,20] for max ~15 A)
       const domain = JSON.parse(currentAxis.getAttribute('data-domain')!) as [number, number];
       expect(domain[0]).toBeLessThan(0);
       expect(domain[1]).toBeGreaterThan(0);

--- a/webapp/src/test/hooks/useWebSocket.test.ts
+++ b/webapp/src/test/hooks/useWebSocket.test.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import { createMockRealtimeDashboard } from '@/test/utils';
 import { createTestQueryClient } from '@/test/utils/test-utils';
@@ -107,12 +107,14 @@ describe('useWebSocket Hook', () => {
 
     const callback = subscriptions.get('/topic/dashboard');
     expect(callback).toBeDefined();
-    callback?.({ body: JSON.stringify(mockData) });
+    act(() => {
+      callback?.({ body: JSON.stringify(mockData) });
+    });
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockData);
       const cached = queryClient.getQueryData(['dashboard']);
-      expect(cached).toEqual(mockData);
+      expect(cached).toEqual({ ...mockData, recent_history: [] });
     });
   });
 

--- a/webapp/src/test/hooks/useWebSocket.test.ts
+++ b/webapp/src/test/hooks/useWebSocket.test.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useWebSocket } from '@/hooks/useWebSocket';
-import { createMockRealtimeDashboard } from '@/test/utils';
+import { createMockMeasurement, createMockRealtimeDashboard } from '@/test/utils';
 import { createTestQueryClient } from '@/test/utils/test-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -115,6 +115,40 @@ describe('useWebSocket Hook', () => {
       expect(result.current.data).toEqual(mockData);
       const cached = queryClient.getQueryData(['dashboard']);
       expect(cached).toEqual({ ...mockData, recent_history: [] });
+    });
+  });
+
+  it('preserves existing recent history when a dashboard message arrives', async () => {
+    const mockData = createMockRealtimeDashboard();
+    const existingHistory = [
+      createMockMeasurement({ time: '2026-07-07T10:00:00.000Z', voltage_rms: 231 }),
+    ];
+
+    queryClient.setQueryData(['dashboard'], {
+      latest_measurement: createMockMeasurement({ voltage_rms: 229 }),
+      waveforms: mockData.waveforms,
+      recent_history: existingHistory,
+    });
+
+    const { result } = renderHook(
+      () => useWebSocket({ url: '/ws', topic: '/topic/dashboard' }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isConnected).toBe(true);
+    });
+
+    const callback = subscriptions.get('/topic/dashboard');
+    expect(callback).toBeDefined();
+    act(() => {
+      callback?.({ body: JSON.stringify(mockData) });
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockData);
+      const cached = queryClient.getQueryData(['dashboard']);
+      expect(cached).toEqual({ ...mockData, recent_history: existingHistory });
     });
   });
 

--- a/webapp/src/test/lib/constants.test.ts
+++ b/webapp/src/test/lib/constants.test.ts
@@ -87,7 +87,7 @@ describe('constants', () => {
         );
       });
 
-      it('nominal voltage (230V) is within acceptable range', () => {
+      it('nominal voltage (230 V) is within acceptable range', () => {
         expect(POWER_QUALITY_LIMITS.NOMINAL_VOLTAGE).toBeGreaterThanOrEqual(
           POWER_QUALITY_LIMITS.VOLTAGE_MIN
         );
@@ -113,7 +113,7 @@ describe('constants', () => {
         );
       });
 
-      it('nominal frequency (50Hz) is within acceptable range', () => {
+      it('nominal frequency (50 Hz) is within acceptable range', () => {
         expect(POWER_QUALITY_LIMITS.NOMINAL_FREQUENCY).toBeGreaterThanOrEqual(
           POWER_QUALITY_LIMITS.FREQUENCY_MIN
         );
@@ -144,9 +144,9 @@ describe('constants', () => {
         expect(POWER_QUALITY_LIMITS.CURRENT_CRITICAL).toBeGreaterThan(0);
       });
 
-      it('warning is approximately 80% of critical (16A)', () => {
+      it('warning is approximately 80% of critical (16 A)', () => {
         const expected_warning = POWER_QUALITY_LIMITS.CURRENT_CRITICAL * 0.8;
-        // 13A is close to 12.8A (80% of 16A), using 0 decimal places tolerance
+        // 13 A is close to 12.8 A (80% of 16 A), using 0 decimal places tolerance
         expect(POWER_QUALITY_LIMITS.CURRENT_WARNING).toBeCloseTo(expected_warning, 0);
       });
     });
@@ -183,7 +183,7 @@ describe('constants', () => {
     });
 
     describe('PN-EN 50160 Standard Compliance', () => {
-      it('voltage range covers ±10% of 230V nominal (207V to 253V)', () => {
+      it('voltage range covers ±10% of 230 V nominal (207 V to 253 V)', () => {
         const nominal = 230;
         const tolerance = 0.1;
 
@@ -194,7 +194,7 @@ describe('constants', () => {
         expect(POWER_QUALITY_LIMITS.VOLTAGE_MAX).toBeCloseTo(expected_max, 5);
       });
 
-      it('frequency range covers ±1% of 50Hz nominal (49.5Hz to 50.5Hz)', () => {
+      it('frequency range covers ±1% of 50 Hz nominal (49.5 Hz to 50.5 Hz)', () => {
         const nominal = 50;
         const tolerance = 0.01;
 

--- a/webapp/src/test/ui/PowerQualitySection.test.tsx
+++ b/webapp/src/test/ui/PowerQualitySection.test.tsx
@@ -268,7 +268,7 @@ describe('PowerQualitySection Component', () => {
       expect(elements.length).toBeGreaterThan(0);
     });
 
-    it('shows Nyquist limitation info box', () => {
+    it('shows reported range limitation info box', () => {
       render(<PowerQualitySection data={mockPowerQualityData} />);
 
       const infoBox = screen.getByText(/Ograniczenia pomiarowe/i);

--- a/webapp/src/test/ui/PowerQualitySection.test.tsx
+++ b/webapp/src/test/ui/PowerQualitySection.test.tsx
@@ -67,11 +67,11 @@ describe('PowerQualitySection Component', () => {
       expect(screen.getByText(/0\.22%/)).toBeInTheDocument();
     });
 
-    it('displays voltage limits (207V - 253V)', () => {
+    it('displays voltage limits (207 V - 253 V)', () => {
       render(<PowerQualitySection data={mockPowerQualityData} />);
 
-      expect(screen.getByText(/207V/)).toBeInTheDocument();
-      expect(screen.getByText(/253V/)).toBeInTheDocument();
+      expect(screen.getByText(/207 V/)).toBeInTheDocument();
+      expect(screen.getByText(/253 V/)).toBeInTheDocument();
     });
 
     it('shows compliance badge for voltage', () => {
@@ -96,11 +96,11 @@ describe('PowerQualitySection Component', () => {
       expect(elements.length).toBeGreaterThan(0);
     });
 
-    it('displays frequency limits (49.5Hz - 50.5Hz)', () => {
+    it('displays frequency limits (49.5 Hz - 50.5 Hz)', () => {
       render(<PowerQualitySection data={mockPowerQualityData} />);
 
-      expect(screen.getByText(/49\.5Hz/)).toBeInTheDocument();
-      expect(screen.getByText(/50\.5Hz/)).toBeInTheDocument();
+      expect(screen.getByText(/49\.5 Hz/)).toBeInTheDocument();
+      expect(screen.getByText(/50\.5 Hz/)).toBeInTheDocument();
     });
   });
 
@@ -122,13 +122,13 @@ describe('PowerQualitySection Component', () => {
       render(<PowerQualitySection data={mockPowerQualityData} />);
 
       expect(screen.getByText(/Ograniczenia pomiarowe/i)).toBeInTheDocument();
-      expect(screen.getByText(/Ograniczenie Nyquista/i)).toBeInTheDocument();
+      expect(screen.getByText(/zakres raportowany/i)).toBeInTheDocument();
     });
 
     it('explains the measurement limitation', () => {
       render(<PowerQualitySection data={mockPowerQualityData} />);
 
-      expect(screen.getByText(/3000Hz/)).toBeInTheDocument();
+      expect(screen.getByText(/10 kHz/)).toBeInTheDocument();
       expect(screen.getByText(/dolne ograniczenie/i)).toBeInTheDocument();
     });
   });
@@ -215,10 +215,10 @@ describe('PowerQualitySection Component', () => {
       expect(screen.getByText(/Parametry napięcia zasilającego/i)).toBeInTheDocument();
     });
 
-    it('shows Nyquist limitation explanation', () => {
+    it('shows harmonic range limitation explanation', () => {
       render(<PowerQualitySection data={mockPowerQualityData} />);
 
-      expect(screen.getByText(/Ograniczenie Nyquista/i)).toBeInTheDocument();
+      expect(screen.getByText(/zakres raportowany/i)).toBeInTheDocument();
       expect(screen.getByText(/IEC 61000-4-7/i)).toBeInTheDocument();
     });
   });

--- a/webapp/src/types/api.ts
+++ b/webapp/src/types/api.ts
@@ -53,8 +53,8 @@ export interface PowerQualityIndicatorsDTO {
 }
 
 export interface WaveformDTO {
-  voltage: number[];  // 200 samples (one 50Hz cycle = 20ms)
-  current: number[];  // 200 samples
+  voltage: number[];  // two cycles, about 400 samples at 50 Hz
+  current: number[];  // two cycles, about 400 samples at 50 Hz
 }
 
 export interface RealtimeDashboardDTO {

--- a/webapp/src/views/Dashboard.tsx
+++ b/webapp/src/views/Dashboard.tsx
@@ -5,20 +5,17 @@ import type { HarmonicsChartHandle } from "@/components/HarmonicsChart";
 import { PowerQualitySection } from "@/components/PowerQualitySection";
 import { StreamingChart } from "@/components/StreamingChart";
 import { Activity, Loader2, AlertCircle, Camera } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { captureAllSections } from "@/hooks/useScreenshotAll";
 import { useDashboardData } from "@/hooks/useDashboardData";
-import { usePowerQualityIndicators } from "@/hooks/usePowerQualityIndicators";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { formatTime, formatDate } from "@/lib/dateUtils";
 import { POWER_QUALITY_LIMITS } from "@/lib/constants";
-import type { MeasurementDTO } from "@/types/api";
+import type { MeasurementDTO, PowerQualityIndicatorsDTO } from "@/types/api";
 
 const Dashboard = () => {
   const [time, setTime] = useState(new Date());
   const { data: dashboardData, isLoading, isError } = useDashboardData();
-  const { data: powerQualityData, isLoading: isPqLoading } =
-    usePowerQualityIndicators();
 
   // WebSocket connection for real-time updates
   const { isConnected, data: websocket_data } = useWebSocket({
@@ -126,6 +123,71 @@ const Dashboard = () => {
     return diff > 0 ? "rising" : "falling";
   };
 
+  const powerQualityData = useMemo<PowerQualityIndicatorsDTO | null>(() => {
+    const measurement = dashboardData?.latest_measurement;
+    if (!measurement) return null;
+
+    const voltageDeviation =
+      measurement.voltage_deviation_percent ??
+      (measurement.voltage_rms !== undefined
+        ? ((measurement.voltage_rms - POWER_QUALITY_LIMITS.NOMINAL_VOLTAGE) /
+            POWER_QUALITY_LIMITS.NOMINAL_VOLTAGE) *
+          100
+        : null);
+
+    const frequencyDeviation =
+      measurement.frequency_deviation_hz ??
+      (measurement.frequency !== undefined
+        ? measurement.frequency - POWER_QUALITY_LIMITS.NOMINAL_FREQUENCY
+        : null);
+
+    const voltageWithinLimits =
+      measurement.voltage_rms === undefined
+        ? null
+        : measurement.voltage_rms >= POWER_QUALITY_LIMITS.VOLTAGE_MIN &&
+          measurement.voltage_rms <= POWER_QUALITY_LIMITS.VOLTAGE_MAX;
+
+    const frequencyWithinLimits =
+      measurement.frequency === undefined
+        ? null
+        : measurement.frequency >= POWER_QUALITY_LIMITS.FREQUENCY_MIN &&
+          measurement.frequency <= POWER_QUALITY_LIMITS.FREQUENCY_MAX;
+
+    const thdWithinLimits =
+      measurement.thd_voltage === undefined
+        ? null
+        : measurement.thd_voltage < POWER_QUALITY_LIMITS.VOLTAGE_THD_LIMIT;
+
+    const complianceValues = [
+      voltageWithinLimits,
+      frequencyWithinLimits,
+      thdWithinLimits,
+    ];
+    const overallCompliant = complianceValues.some((value) => value === null)
+      ? null
+      : complianceValues.every(Boolean);
+
+    return {
+      timestamp: measurement.time ?? new Date().toISOString(),
+      voltage_rms: measurement.voltage_rms ?? 0,
+      voltage_deviation_percent: voltageDeviation,
+      voltage_within_limits: voltageWithinLimits,
+      frequency: measurement.frequency ?? 0,
+      frequency_deviation_hz: frequencyDeviation,
+      frequency_within_limits: frequencyWithinLimits,
+      thd_voltage: measurement.thd_voltage ?? 0,
+      thd_within_limits: thdWithinLimits,
+      harmonics_voltage: measurement.harmonics_v ?? [],
+      overall_compliant: overallCompliant,
+      status_message:
+        overallCompliant === null
+          ? "Brak pełnych danych"
+          : overallCompliant
+            ? "Wszystkie wskaźniki w normie"
+            : "Wykryto odchylenia",
+    };
+  }, [dashboardData?.latest_measurement]);
+
   return (
     <div className="bg-background grid-pattern">
       {/* Status Bar */}
@@ -199,18 +261,7 @@ const Dashboard = () => {
         {/* PN-EN 50160 Power Quality Indicators */}
         {!isLoading && !isError && (
           <>
-            {isPqLoading && (
-              <section className="mb-6 sm:mb-8">
-                <div className="flex items-center gap-3 bg-card/50 border border-border rounded-lg p-6">
-                  <Loader2 className="w-5 h-5 animate-spin text-primary" />
-                  <span className="text-sm text-muted-foreground">
-                    Ładowanie wskaźników jakości energii...
-                  </span>
-                </div>
-              </section>
-            )}
-
-            {powerQualityData && !isPqLoading && (
+            {powerQualityData && (
               <div ref={powerQualityRef}>
                 <PowerQualitySection data={powerQualityData} />
               </div>
@@ -284,7 +335,7 @@ const Dashboard = () => {
                 value={(
                   dashboardData.latest_measurement.power_distortion ?? 0
                 ).toFixed(1)}
-                unit="var"
+                unit="VAr"
                 status="normal"
                 statusLabel="Diagnostyczny"
                 min="0"
@@ -321,7 +372,7 @@ const Dashboard = () => {
               <ParameterCard
                 title="Moc bierna"
                 value={(dashboardData.latest_measurement.power_reactive ?? 0).toFixed(1)}
-                unit="VAR"
+                unit="VAr"
                 status="normal"
                 statusLabel="Normalny"
                 min="0"

--- a/webapp/src/views/Dashboard.tsx
+++ b/webapp/src/views/Dashboard.tsx
@@ -156,7 +156,7 @@ const Dashboard = () => {
     const thdWithinLimits =
       measurement.thd_voltage === undefined
         ? null
-        : measurement.thd_voltage < POWER_QUALITY_LIMITS.VOLTAGE_THD_LIMIT;
+        : measurement.thd_voltage <= POWER_QUALITY_LIMITS.VOLTAGE_THD_LIMIT;
 
     const complianceValues = [
       voltageWithinLimits,

--- a/webapp/src/views/History.tsx
+++ b/webapp/src/views/History.tsx
@@ -50,7 +50,7 @@ export default function History() {
       "Prąd (A)",
       "Moc czynna (W)",
       "Moc pozorna (VA)",
-      "Moc bierna (VAR)",
+      "Moc bierna (VAr)",
       "Współczynnik mocy",
       "Częstotliwość (Hz)",
       "THD napięcia (%)",


### PR DESCRIPTION
## Summary

- Switch ESP32 sampling to ADC continuous DMA on ADC1 channels for voltage and current.
- Keep two-period waveform export while using the higher internal sampling rate for calculations.
- Fix dashboard THD consistency by deriving PN-EN 50160 indicators from the same latest measurement as the real-time cards.
- Correct scientific unit labels and stale sampling descriptions across frontend/backend comments and tests.

## Why

The previous timer/analogRead sampling path introduced jitter and made the current waveform visibly jagged. It also left the UI and documentation with stale 3 kHz / 512-sample assumptions. The dashboard additionally showed different THD voltage values because two sections were reading different refresh paths.

## Validation

- `pio run`
- `npm run build`
- `npm test -- WaveformChart`
- `npm test -- useWebSocket HarmonicsChart PowerQualitySection`
- `./mvnw -Dtest=MeasurementValidatorTest test`

Full `./mvnw test` was attempted but is currently blocked by Mockito/ByteBuddy self-attach failures on JDK 26 in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zwiększono próbkowanie do **10 kHz** i obsługę przebiegów z **dwóch okresów**.
  * Raportowane harmoniczne obejmują zakres **H1–H25** (a **THD** jest wartością częściową/dolnym ograniczeniem).
  * Dashboard oraz wykresy dopasowują format danych do nowej struktury.
* **Bug Fixes**
  * Ulepszono eksport i prezentację przebiegów (mniej punktów, dopasowanie do rzeczywistej częstotliwości).
  * Poprawiono oznaczenia **mocy biernej: VAr**.
* **Documentation**
  * Zaktualizowano opisy limitów, komunikaty walidacji i treść ostrzeżeń jednostek.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->