### PR TITLE
Fix overlapping power parameter migration

### DIFF
--- a/scada-system/src/main/resources/db/migration/V7__Add_power_distortion_and_power_factor.sql
+++ b/scada-system/src/main/resources/db/migration/V7__Add_power_distortion_and_power_factor.sql
@@ -1,17 +1,11 @@
--- Add power_distortion column (D = sqrt(S² - P² - Q₁²))
--- Represents power component from harmonics according to Budeanu theory
-ALTER TABLE measurements
-    ADD COLUMN power_distortion DOUBLE PRECISION NULL;
-
--- Rename cos_phi to power_factor (λ = P/S)
--- This is more accurate terminology as cos(φ) is only valid for sinusoidal waveforms
--- while λ = P/S is valid for all waveforms including distorted ones
-ALTER TABLE measurements
-    RENAME COLUMN cos_phi TO power_factor;
-
--- Update comments for power_reactive column
-COMMENT ON COLUMN measurements.power_reactive IS 'Reactive power of fundamental Q₁ (var). Formula: Q₁ = U₁ * I₁ * sin(φ₁) where φ₁ is phase shift of H1 only. For distorted waveforms this is NOT total reactive power - see also power_distortion.';
-
-COMMENT ON COLUMN measurements.power_distortion IS 'Distortion power D (var). Formula: D = sqrt(S² - P² - Q₁²). Represents power from harmonics (Budeanu theory). Zero for sinusoidal waveforms.';
-
-COMMENT ON COLUMN measurements.power_factor IS 'Power factor λ = P/S. Valid for all waveforms. NOT cos(φ) which is only valid for sinusoidal waveforms. For distorted waveforms: λ < cos(φ₁).';
+-- Migration V7: Superseded by V5 power-parameter refactor
+--
+-- V5 already replaces the legacy power columns by dropping cos_phi and
+-- power_reactive, then adding:
+-- - power_reactive_fund
+-- - power_distortion
+-- - power_factor
+-- - phase_shift
+--
+-- Keep this version as a no-op so clean databases can migrate past V7 without
+-- re-adding or renaming columns that no longer exist after V5.


### PR DESCRIPTION
## Summary
- make `V7__Add_power_distortion_and_power_factor.sql` a documented no-op
- avoid re-adding `power_distortion`, renaming removed `cos_phi`, or commenting removed `power_reactive` after V5 already owns the power-column refactor

## Why
A clean Flyway migration sequence can fail because V5 already drops/replaces the old power columns, while V7 tried to operate on those same legacy columns again.

## Validation
- `git diff --check master..HEAD -- scada-system/src/main/resources/db/migration/V7__Add_power_distortion_and_power_factor.sql`
- `./mvnw -DskipTests compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migracja wersji 7 została oznaczona jako nieaktywna i zastąpiona informacją, że zmiany są już uwzględnione wcześniej.
  * Usunięto zbędne kroki zmieniające schemat bazy danych w tej wersji.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->