### PR TITLE
Align backend THD limit boundary handling

### DIFF
--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java
@@ -338,14 +338,14 @@ public class MeasurementService {
     }
 
     /**
-     * Check if THD is within PN-EN 50160 limit (<8%).
+     * Check if THD is within PN-EN 50160 limit (<=8%).
      * Note: Our THD is partial (harmonics 2-25 only), representing lower bound.
      */
     private Boolean checkThdCompliance(Double thdVoltage) {
         if (thdVoltage == null) {
             return null;
         }
-        return thdVoltage < Constants.VOLTAGE_THD_LIMIT;
+        return thdVoltage <= Constants.VOLTAGE_THD_LIMIT;
     }
 
     private PowerQualityIndicatorsDTO buildPowerQualityIndicatorsDTO(Measurement measurement) {

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java
@@ -7,6 +7,7 @@ import com.dkowalczyk.scadasystem.model.dto.PowerQualityIndicatorsDTO;
 import com.dkowalczyk.scadasystem.model.dto.ValidationResult;
 import com.dkowalczyk.scadasystem.model.entity.Measurement;
 import com.dkowalczyk.scadasystem.repository.MeasurementRepository;
+import com.dkowalczyk.scadasystem.util.Constants;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -59,6 +60,28 @@ class MeasurementServiceTest extends BaseServiceTest {
         assertThat(dto.getThdVoltage()).isEqualTo(5.0);
         assertThat(dto.getVoltageWithinLimits()).isTrue();
         assertThat(dto.getFrequencyWithinLimits()).isTrue();
+        assertThat(dto.getThdWithinLimits()).isTrue();
+        assertThat(dto.getOverallCompliant()).isTrue();
+        assertThat(dto.getStatusMessage()).contains("within PN-EN 50160");
+    }
+
+    @Test
+    void getLatestPowerQualityIndicators_treatsExactThdLimitAsCompliant() {
+        Measurement measurement = Measurement.builder()
+            .time(Instant.now())
+            .voltageRms(230.0)
+            .frequency(50.0)
+            .thdVoltage(Constants.VOLTAGE_THD_LIMIT)
+            .harmonicsV(new Double[]{1.0, 2.0, 3.0})
+            .voltageDeviationPercent(0.0)
+            .frequencyDeviationHz(0.0)
+            .build();
+        when(repository.findTopByIsValidTrueOrderByTimeDesc()).thenReturn(Optional.of(measurement));
+
+        Optional<PowerQualityIndicatorsDTO> result = measurementService.getLatestPowerQualityIndicators();
+
+        assertThat(result).isPresent();
+        PowerQualityIndicatorsDTO dto = result.get();
         assertThat(dto.getThdWithinLimits()).isTrue();
         assertThat(dto.getOverallCompliant()).isTrue();
         assertThat(dto.getStatusMessage()).contains("within PN-EN 50160");


### PR DESCRIPTION
## Summary
- treat exactly `Constants.VOLTAGE_THD_LIMIT` as compliant in backend power-quality indicators
- add a regression test for the exact THD limit boundary

## Why
The frontend/card behavior treats values at the voltage THD limit as normal, while the backend summary used a strict `<` comparison and marked the same value non-compliant.

## Validation
- `git diff --check master..HEAD -- scada-system/src/main/java/com/dkowalczyk/scadasystem/service/MeasurementService.java scada-system/src/test/java/com/dkowalczyk/scadasystem/service/MeasurementServiceTest.java`
- `./mvnw -Dtest=MeasurementServiceTest test`