### PR TITLE
Make backend CORS origins configurable

### DIFF
--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/config/CorsConfig.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/config/CorsConfig.java
@@ -1,21 +1,28 @@
 package com.dkowalczyk.scadasystem.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.*;
 
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
+    private final String[] allowedOrigins;
+
+    public CorsConfig(@Value("${cors.allowed-origins}") String[] allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("*")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*");
 
         // Allow CORS for WebSocket endpoint (SockJS handshake needs CORS)
         registry.addMapping("/ws/**")
-                .allowedOrigins("*")
+                .allowedOrigins(allowedOrigins)
                 .allowedMethods("GET", "POST")
                 .allowedHeaders("*");
     }

--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/config/WebSocketConfig.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.dkowalczyk.scadasystem.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.*;
@@ -7,6 +8,12 @@ import org.springframework.web.socket.config.annotation.*;
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final String[] allowedOrigins;
+
+    public WebSocketConfig(@Value("${cors.allowed-origins}") String[] allowedOrigins) {
+        this.allowedOrigins = allowedOrigins;
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -17,7 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws/measurements")
-                .setAllowedOriginPatterns("*")  // Use patterns instead of origins for wildcard
+                .setAllowedOrigins(allowedOrigins)
                 .withSockJS();
     }
 }

--- a/scada-system/src/main/resources/application.properties
+++ b/scada-system/src/main/resources/application.properties
@@ -36,6 +36,9 @@ mqtt.password=
 spring.jackson.serialization.write-dates-as-timestamps=false
 spring.jackson.property-naming-strategy=SNAKE_CASE
 
+# CORS / WebSocket allowed origins
+cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://127.0.0.1:5173}
+
 # Logging
 logging.level.com.dkowalczyk.scadasystem=DEBUG
 logging.level.org.springframework.web=INFO


### PR DESCRIPTION
## Summary
- replace wildcard REST and SockJS/WebSocket origins with config-driven allowed origins
- add `cors.allowed-origins`, defaulting to local Vite origins

## Why
Wildcard origins are convenient in development but too broad for deployment. This keeps local defaults working while allowing deployment-specific origins via `CORS_ALLOWED_ORIGINS`.

## Validation
- `git diff --check master..HEAD -- scada-system/src/main/java/com/dkowalczyk/scadasystem/config/CorsConfig.java scada-system/src/main/java/com/dkowalczyk/scadasystem/config/WebSocketConfig.java scada-system/src/main/resources/application.properties`
- `./mvnw -DskipTests compile`