### PR TITLE
Make daily stats recalculation idempotent

### DIFF
--- a/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java
+++ b/scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java
@@ -179,36 +179,29 @@ public class StatsService {
         double dataCompleteness = (double) measurementCount / expectedMeasurements;
 
         // === Persist Calculated Stats ===
-        DailyStats dailyStats = DailyStats.builder()
-                .date(date)
-                // Voltage
-                .avgVoltage(avgVoltage)
-                .minVoltage(minVoltage)
-                .maxVoltage(maxVoltage)
-                .stdDevVoltage(stdDevVoltage)
-                // Power
-                .avgPowerActive(avgPowerActive)
-                .minPower(minPowerActive)
-                .peakPower(maxPowerActive)
-                .totalEnergyKwh(totalEnergyKwh)
-                // Power factor
-                .avgPowerFactor(avgPowerFactor)
-                .minPowerFactor(minPowerFactor)
-                // Frequency
-                .avgFrequency(avgFrequency)
-                .minFrequency(minFrequency)
-                .maxFrequency(maxFrequency)
-                // Event counters
-                .voltageSagCount(voltageSagCount)
-                .voltageSwellCount(voltageSwellCount)
-                .interruptionCount(interruptionCount)
-                .thdViolationsCount(thdViolationsCount)
-                .frequencyDevCount(frequencyDevCount)
-                .powerFactorPenaltyCount(powerFactorPenaltyCount)
-                // Data quality
-                .measurementCount(measurementCount)
-                .dataCompleteness(dataCompleteness)
-                .build();
+        DailyStats dailyStats = repository.findByDate(date).orElseGet(DailyStats::new);
+        dailyStats.setDate(date);
+        dailyStats.setAvgVoltage(avgVoltage);
+        dailyStats.setMinVoltage(minVoltage);
+        dailyStats.setMaxVoltage(maxVoltage);
+        dailyStats.setStdDevVoltage(stdDevVoltage);
+        dailyStats.setAvgPowerActive(avgPowerActive);
+        dailyStats.setMinPower(minPowerActive);
+        dailyStats.setPeakPower(maxPowerActive);
+        dailyStats.setTotalEnergyKwh(totalEnergyKwh);
+        dailyStats.setAvgPowerFactor(avgPowerFactor);
+        dailyStats.setMinPowerFactor(minPowerFactor);
+        dailyStats.setAvgFrequency(avgFrequency);
+        dailyStats.setMinFrequency(minFrequency);
+        dailyStats.setMaxFrequency(maxFrequency);
+        dailyStats.setVoltageSagCount(voltageSagCount);
+        dailyStats.setVoltageSwellCount(voltageSwellCount);
+        dailyStats.setInterruptionCount(interruptionCount);
+        dailyStats.setThdViolationsCount(thdViolationsCount);
+        dailyStats.setFrequencyDevCount(frequencyDevCount);
+        dailyStats.setPowerFactorPenaltyCount(powerFactorPenaltyCount);
+        dailyStats.setMeasurementCount(measurementCount);
+        dailyStats.setDataCompleteness(dataCompleteness);
 
         repository.save(dailyStats);
 

--- a/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
+++ b/scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java
@@ -465,6 +465,34 @@ class StatsServiceTest {
     }
 
     @Test
+    @DisplayName("calculateDailyStats() should update existing daily stats for date")
+    void calculateDailyStats_shouldUpdateExistingDailyStats_forDate() {
+        // Given: Existing stale stats for the same date and fresh measurements
+        List<Measurement> measurements = createNormalMeasurements();
+        DailyStats existingStats = createMockDailyStats(testDate);
+        existingStats.setId(42L);
+        existingStats.setAvgVoltage(1.0);
+        existingStats.setMeasurementCount(0);
+        mockRepositoryCalls(measurements);
+        when(dailyStatsRepository.findByDate(testDate)).thenReturn(Optional.of(existingStats));
+
+        // When: Recalculate daily stats
+        statsService.calculateDailyStats(testDate);
+
+        // Then: Should update and save the existing row instead of inserting a new one
+        ArgumentCaptor<DailyStats> captor = ArgumentCaptor.forClass(DailyStats.class);
+        verify(dailyStatsRepository).findByDate(testDate);
+        verify(dailyStatsRepository).save(captor.capture());
+
+        DailyStats saved = captor.getValue();
+        assertThat(saved).isSameAs(existingStats);
+        assertThat(saved.getId()).isEqualTo(42L);
+        assertThat(saved.getDate()).isEqualTo(testDate);
+        assertThat(saved.getAvgVoltage()).isEqualTo(230.0);
+        assertThat(saved.getMeasurementCount()).isEqualTo(3);
+    }
+
+    @Test
     @DisplayName("calculateDailyStats() should calculate data completeness correctly")
     void calculateDailyStats_shouldCalculateDataCompleteness_correctly() {
         // Given: Expected measurements = 24 * 60 * 60 / 3 = 28,800


### PR DESCRIPTION
## Summary
- update existing `DailyStats` rows when recalculating a date
- add a regression test proving the same entity/id is saved during recalculation

## Why
`calculateDailyStats(date)` always built a new entity, so manual recalculation/backfill for an existing date could violate the unique `date` constraint instead of updating the existing row.

## Validation
- `git diff --check master..HEAD -- scada-system/src/main/java/com/dkowalczyk/scadasystem/service/StatsService.java scada-system/src/test/java/com/dkowalczyk/scadasystem/service/StatsServiceTest.java`
- `./mvnw -Dtest=StatsServiceTest test`