### PR TITLE
Update browser branding

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -2,9 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/scada-favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>webapp</title>
+    <meta name="theme-color" content="#0f172a" />
+    <title>SCADA Web Dashboard</title>
   </head>
   <body>
     <div id="root"></div>

--- a/webapp/public/scada-favicon.svg
+++ b/webapp/public/scada-favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0f172a"/>
+  <path d="M12 40c7-18 13-18 20 0s13 18 20 0" fill="none" stroke="#38bdf8" stroke-width="5" stroke-linecap="round"/>
+  <path d="M12 24h40" stroke="#f59e0b" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="32" cy="32" r="5" fill="#22c55e"/>
+</svg>


### PR DESCRIPTION
## Summary

- Replace the default Vite favicon with a SCADA-themed SVG favicon.
- Set the browser tab title to `SCADA Web Dashboard`.
- Add a browser theme color matching the dashboard shell.

## Validation

- `npm run build`